### PR TITLE
Fix lowering performance

### DIFF
--- a/llvm/lib/Target/TVM/TVMISelLowering.h
+++ b/llvm/lib/Target/TVM/TVMISelLowering.h
@@ -18,6 +18,7 @@
 #include "TVM.h"
 #include "llvm/CodeGen/SelectionDAG.h"
 #include "llvm/CodeGen/TargetLowering.h"
+#include <set>
 
 namespace llvm {
 
@@ -116,6 +117,9 @@ private:
   // Save/restore C0 for return lowering
   SDValue SaveC0(SDValue Chain, const SDLoc &DL, SelectionDAG& DAG) const;
   SDValue RestoreC0(SDValue Chain, const SDLoc &DL, SelectionDAG& DAG) const;
+
+  bool hasPushC0Predecessor(SDNode *Node) const;
+  mutable std::set<int> HasNoPushC0PredecessorCache;
 };
 } // namespace llvm
 


### PR DESCRIPTION
Code generation for [repro.ll.txt](https://github.com/tonlabs/TON-Compiler/files/3758714/repro.ll.txt) takes several minutes (562s on my machine) in debug mode and ~45s in release.

The change reduces the time to a fraction of second.