### PR TITLE
Diamond basic block inlining for IFELSE

### DIFF
--- a/llvm/lib/Target/TVM/TVMMachineInstrMatcher.h
+++ b/llvm/lib/Target/TVM/TVMMachineInstrMatcher.h
@@ -1,0 +1,102 @@
+//===-- TVMMachineInstrMatcher.h - Define TVM subtarget ---------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIB_TARGET_TVM_TVMMACHINEINSTRMATCHER_H
+#define LLVM_LIB_TARGET_TVM_TVMMACHINEINSTRMATCHER_H
+
+#include "llvm/CodeGen/MachineBasicBlock.h"
+
+namespace llvm {
+
+/// Implements MI matcher with several immediate arguments
+class MachineInstrMatcher {
+public:
+  MachineInstrMatcher(MachineBasicBlock::instr_iterator It,
+                      MachineBasicBlock::instr_iterator End)
+      : It(It), End(End) {}
+
+  /// Returns match if instruction has required opcode
+  MachineInstr *match(unsigned int Opcode) {
+    MachineInstr *Instr = next();
+
+    if (!Instr)
+      return nullptr;
+
+    if (Instr->getOpcode() != Opcode)
+      return nullptr;
+
+    return Instr;
+  }
+
+  /// Returns match if instruction has required opcode and specified
+  /// argument values
+  template <typename... ArgsT>
+  MachineInstr *match(unsigned int Opcode, ArgsT... Args) {
+    return matchImpl(match(Opcode), 0, Args...);
+  }
+
+  template <typename... ArgsT>
+  bool match(MachineInstr *&Instr, unsigned int Opcode, ArgsT... Args) {
+    Instr = match(Opcode, Args...);
+
+    return Instr != nullptr;
+  }
+
+  MachineBasicBlock::instr_iterator iter() { return It; }
+
+private:
+  MachineInstr *next() {
+    if (It == End)
+      return nullptr;
+
+    return &*It++;
+  }
+
+  bool checkOperand(MachineInstr *Instr, unsigned int Index, int ImmValue) {
+    if (!Instr)
+      return false;
+
+    if (Index >= Instr->getNumOperands())
+      return false;
+
+    const MachineOperand &Operand = Instr->getOperand(Index);
+
+    if (!Operand.isImm())
+      return false;
+
+    if (ImmValue != Operand.getImm())
+      return false;
+
+    return true;
+  }
+
+  MachineInstr *matchImpl(MachineInstr *Instr, unsigned int Index, int First) {
+    if (!checkOperand(Instr, Index, First))
+      return nullptr;
+
+    return Instr;
+  }
+
+  template <typename... ArgsT>
+  MachineInstr *matchImpl(MachineInstr *Instr, unsigned int Index, int First,
+                          ArgsT... Args) {
+    if (!checkOperand(Instr, Index, First))
+      return nullptr;
+
+    return matchImpl(Instr, Index + 1, Args...);
+  }
+
+private:
+  MachineBasicBlock::instr_iterator It;
+  MachineBasicBlock::instr_iterator End;
+};
+
+}
+
+#endif

--- a/llvm/lib/Target/TVM/TVMPeephole.cpp
+++ b/llvm/lib/Target/TVM/TVMPeephole.cpp
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "TVM.h"
+#include "TVMMachineInstrMatcher.h"
 #include "TVMMachineFunctionInfo.h"
 #include "TVMSubtarget.h"
 #include "TVMUtilities.h"
@@ -44,7 +45,10 @@ class TVMPeephole final : public MachineFunctionPass {
                               const TargetInstrInfo &TII);
   bool runImplicitReturnOptimization(MachineBasicBlock &MBB,
                                      const TargetInstrInfo &TII);
-  bool runMbbInlineOptimization(MachineBasicBlock &MBB);
+  bool runMbbInlineOptimization(MachineBasicBlock &MBB,
+                                const TargetInstrInfo &TII);
+  bool runIfElseInlineOptimization(MachineBasicBlock &MBB,
+                                   const TargetInstrInfo &TII);
 
 public:
   static char ID;
@@ -84,7 +88,11 @@ bool TVMPeephole::runImplicitReturnOptimization(MachineBasicBlock &MBB,
   return MI.isReturn() && MaybeOptimizeReturn(MI, TII);
 }
 
-bool TVMPeephole::runMbbInlineOptimization(MachineBasicBlock &MBB) {
+bool TVMPeephole::runMbbInlineOptimization(MachineBasicBlock &MBB,
+                                           const TargetInstrInfo &TII) {
+  if (MBB.empty())
+    return false;
+
   auto InstrIter = MBB.instr_rbegin();
   auto &JmpX = *InstrIter;
 
@@ -93,7 +101,27 @@ bool TVMPeephole::runMbbInlineOptimization(MachineBasicBlock &MBB) {
 
   ++InstrIter;
 
-  if (InstrIter == MBB.instr_rend())
+  auto FirstStackInstrIter = InstrIter;
+  bool PushContMBBFound = false;
+
+  for (; InstrIter != MBB.instr_rend() && !PushContMBBFound;) {
+    switch (InstrIter->getOpcode()) {
+    case TVM::PUSHCONT_MBB_S:
+      PushContMBBFound = true;
+      break;
+    // Auxilary stack operations should be skipped here and then converted
+    // below to transform the MI sequence to (PUSHCONT, JMPX) form
+    case TVM::NIP:
+      ++InstrIter;
+      break;
+    default:
+      return false;
+    }
+  }
+
+  auto LastStackInstrIter = InstrIter;
+
+  if (!PushContMBBFound)
     return false;
 
   auto &PushContMBB = *InstrIter;
@@ -112,6 +140,24 @@ bool TVMPeephole::runMbbInlineOptimization(MachineBasicBlock &MBB) {
   auto InsertionIter = InstrIter.getReverse();
   MachineFunction *MF = MBB.getParent();
 
+  // Convert MI sequence to expected form (PUSHCONT, JMPX) and move all
+  // stack operations between PUSHCONT and JMPX before the PUSHCONT
+  // (the list of possible transformations may be extended in future)
+  for (InstrIter = FirstStackInstrIter; InstrIter != LastStackInstrIter;) {
+    switch (InstrIter->getOpcode()) {
+    case TVM::NIP:
+      BuildMI(&*InsertionIter, TII.get(TVM::DROP));
+      break;
+    default:
+      break;
+    }
+
+    auto Next = InstrIter;
+    ++Next;
+    InstrIter->eraseFromParent();
+    InstrIter = Next;
+  }
+
   for (auto &MI : SourceMBB) {
     MF->CloneMachineInstrBundle(MBB, InsertionIter, MI);
   }
@@ -122,14 +168,92 @@ bool TVMPeephole::runMbbInlineOptimization(MachineBasicBlock &MBB) {
   return true;
 }
 
+bool TVMPeephole::runIfElseInlineOptimization(MachineBasicBlock &MBB,
+                                              const TargetInstrInfo &TII) {
+  auto InstrIter = MBB.instr_begin();
+  bool Changed = false;
+
+  for (; InstrIter != MBB.instr_end(); ++InstrIter) {
+    MachineInstrMatcher Matcher(InstrIter, MBB.instr_end());
+
+    MachineInstr *PushContA = nullptr;
+    MachineInstr *PushContB = nullptr;
+    MachineInstr *PushContC = nullptr;
+    MachineInstr *Roll = nullptr;
+    MachineInstr *Blkswap = nullptr;
+    MachineInstr *Swap = nullptr;
+    MachineInstr *Ifelse = nullptr;
+
+    if (!Matcher.match(PushContA, TVM::PUSHCONT_MBB_S) ||
+        !Matcher.match(PushContB, TVM::PUSHCONT_MBB_S) ||
+        !Matcher.match(PushContC, TVM::PUSHCONT_MBB_S) ||
+        !Matcher.match(Roll, TVM::ROLL, 3) ||
+        !Matcher.match(Blkswap, TVM::BLKSWAP, 2, 2) ||
+        !Matcher.match(Swap, TVM::SWAP) ||
+        !Matcher.match(Ifelse, TVM::IFELSE_S)) {
+      continue;
+    }
+
+    MachineBasicBlock *ContA = PushContA->getOperand(0).getMBB();
+    MachineBasicBlock *ContB = PushContB->getOperand(0).getMBB();
+    MachineBasicBlock *ContC = PushContC->getOperand(0).getMBB();
+
+    assert(ContA && ContB && ContC &&
+           "PUSHCONT_MBB_S should have MachineBasicBlock as an operand #0");
+
+    if (ContA->empty() || ContB->empty()) {
+      continue;
+    }
+
+    MachineInstr &ContAJmpX = ContA->instr_back();
+    MachineInstr &ContBJmpX = ContB->instr_back();
+
+    if (ContAJmpX.getOpcode() != TVM::JMPX_S ||
+        ContBJmpX.getOpcode() != TVM::JMPX_S) {
+      continue;
+    }
+
+    LLVM_DEBUG({
+      dbgs() << "  inline IFELSE post-dominator  %bb." +
+                    Twine(ContC->getNumber())
+             << "\n";
+    });
+
+    InstrIter = --Matcher.iter();
+
+    MachineFunction *MF = MBB.getParent();
+    auto InsertionIter = InstrIter;
+    InsertionIter++;
+
+    for (auto &MI : *ContC) {
+      MF->CloneMachineInstrBundle(MBB, InsertionIter, MI);
+    }
+
+    BuildMI(&ContAJmpX, TII.get(TVM::FALLTHROUGH_RETURN));
+    BuildMI(&ContBJmpX, TII.get(TVM::FALLTHROUGH_RETURN));
+
+    PushContC->eraseFromParent();
+    Roll->eraseFromParent();
+    Blkswap->eraseFromParent();
+    Swap->eraseFromParent();
+
+    ContAJmpX.eraseFromParent();
+    ContBJmpX.eraseFromParent();
+
+    Changed = true;
+  }
+
+  return Changed;
+}
+
 bool TVMPeephole::runOnMachineBasicBlock(MachineBasicBlock &MBB,
                                          const TargetInstrInfo &TII) {
   bool Changed = false;
 
-  Changed |= runImplicitReturnOptimization(MBB, TII);
-
-  while (runMbbInlineOptimization(MBB))
+  while (runMbbInlineOptimization(MBB, TII))
     Changed |= true;
+
+  Changed |= runImplicitReturnOptimization(MBB, TII);
 
   return Changed;
 }
@@ -148,6 +272,10 @@ bool TVMPeephole::runOnMachineFunction(MachineFunction &MF) {
 
   for (auto &MBB : MF) {
     Changed |= runOnMachineBasicBlock(MBB, *TII);
+  }
+
+  for (auto &MBB : MF) {
+    Changed |= runIfElseInlineOptimization(MBB, *TII);
   }
 
   return Changed;

--- a/llvm/test/CodeGen/TVM/optimizations/pushcont_inline.ll
+++ b/llvm/test/CodeGen/TVM/optimizations/pushcont_inline.ll
@@ -9,8 +9,7 @@ define void @g(i257 %x) {
 ; CHECK-NEXT: {
 ; CHECK-NEXT: ; %bb.1: ; %if.then
 ; CHECK-NEXT: ; {{.*}}
-; CHECK-NEXT:   JMPX
-; CHECK-NEXT: }
+; CHECK-NEXT: ; fallthrough return
   %x.addr = alloca i257, align 1
   store i257 %x, i257* %x.addr, align 1
   %tobool = icmp ne i257 %x, 0
@@ -29,3 +28,54 @@ return:
 }
 
 declare dso_local i257 @f(i257) #1
+
+; CHECK-LABEL: k
+define dso_local void @k(i257 %x) #0 {
+; CHECK: PUSHCONT ; >%4 =
+; CHECK-NEXT: ; {{.*}}
+; CHECK-NEXT: {
+; CHECK-NEXT: ; %bb.2: ; %if.else
+; CHECK: ; fallthrough return
+; CHECK: PUSHCONT ; >%5 =
+; CHECK-NEXT: ; {{.*}}
+; CHECK-NEXT: {
+; CHECK-NEXT: ; %bb.1: ; %if.then
+; CHECK: ; fallthrough return
+; CHECK: }
+; CHECK: IFELSE
+entry:
+  %x.addr = alloca i257, align 1
+  %y = alloca i257, align 1
+  store i257 %x, i257* %x.addr, align 1
+  store i257 0, i257* %y, align 1
+  %0 = load i257, i257* %x.addr, align 1
+  %tobool = icmp ne i257 %0, 0
+  br i1 %tobool, label %if.then, label %if.else
+
+if.then:                                          ; preds = %entry
+  %1 = load i257, i257* %x.addr, align 1
+  %call = call i257 @f1(i257 %1)
+  %2 = load i257, i257* %x.addr, align 1
+  %call1 = call i257 @f1(i257 %2)
+  %mul = mul nsw i257 %call, %call1
+  store i257 %mul, i257* %y, align 1
+  br label %if.end
+
+if.else:                                          ; preds = %entry
+  %3 = load i257, i257* %x.addr, align 1
+  %call2 = call i257 @f2(i257 %3)
+  %4 = load i257, i257* %x.addr, align 1
+  %call3 = call i257 @f2(i257 %4)
+  %add = add nsw i257 %call2, %call3
+  store i257 %add, i257* %y, align 1
+  br label %if.end
+
+if.end:                                           ; preds = %if.else, %if.then
+  %5 = load i257, i257* %y, align 1
+  %call4 = call i257 @f3(i257 %5)
+  ret void
+}
+
+declare dso_local i257 @f1(i257) #1
+declare dso_local i257 @f2(i257) #1
+declare dso_local i257 @f3(i257) #1


### PR DESCRIPTION
This PR implements inlining of post-dominator basic block which is called by JMPX as a last instruction within both then/else basic blocks. So instead of JMPX to such block its instructions are moved after the IFELSE instruction.