### PR TITLE
Unwrap CALLN's target address during ISel

### DIFF
--- a/llvm/lib/Target/TVM/TVMISelDAGToDAG.cpp
+++ b/llvm/lib/Target/TVM/TVMISelDAGToDAG.cpp
@@ -118,6 +118,8 @@ void TVMDAGToDAGISel::Select(SDNode *Node) {
   }
   case TVMISD::CALLN: {
     SmallVector<SDValue, 16> Ops(std::next(Node->op_begin()), Node->op_end());
+    assert(Ops[0].getOpcode() == TVMISD::GLOBAL_ADDRESS_WRAPPER);
+    Ops[0] = Ops[0].getOperand(0); // unwrap the address
     auto SzVal = Ops.back();
     unsigned Sz = cast<ConstantSDNode>(SzVal)->getZExtValue();
     Ops.pop_back();

--- a/llvm/test/CodeGen/TVM/call/calln.ll
+++ b/llvm/test/CodeGen/TVM/call/calln.ll
@@ -1,0 +1,14 @@
+; RUN: llc -march=tvm -asm-verbose=false < %s | FileCheck %s
+target datalayout = "E-S257-i1:257:257-i8:257:257-i16:257:257-i32:257:257-i64:257:257-i257:257:257-p:257:257-a:257:257"
+target triple = "tvm"
+
+%st = type { i257, i257, i257 }
+declare %st @bar()
+
+define void @foo() {
+; CHECK-LABEL: foo
+; CHECK: CALL $bar$
+; CHECK-NEXT: BLKDROP 3
+  %call = call %st @bar()
+  ret void
+}


### PR DESCRIPTION
It's the same logic as for CALL0/CALL1, just doing this manually for CALLN.