### PR TITLE
Make signed function attribute optional

### DIFF
--- a/llvm/lib/Target/TVM/TVMStackModel.cpp
+++ b/llvm/lib/Target/TVM/TVMStackModel.cpp
@@ -620,6 +620,10 @@ void TVMStackModel::modelInstructionExecution(MachineInstr &MI,
 
 void TVMStackModel::rewriteToSForm(MachineInstr &MI, std::string &PreTermStackString,
                                    Stack &TheStack) {
+  if (MI.isImplicitDef()) {
+    MI.eraseFromParent();
+    return;
+  }
   size_t NumDefs = MI.getNumDefs();
   size_t NumOperands = MI.getNumOperands();
   int NewOpcode = TVM::RegForm2SForm[MI.getOpcode()];

--- a/llvm/tools/tvm-build/tvm-build.py
+++ b/llvm/tools/tvm-build/tvm-build.py
@@ -106,7 +106,7 @@ if args.cflags:
 
 for filename in input_c:
   _, tmp_file = tempfile.mkstemp()
-  execute([os.path.join(tvm_llvm_bin, 'clang'), '-target', 'tvm'] +
+  execute([os.path.join(tvm_llvm_bin, 'clang'), '-target', 'tvm', '-isystem', tvm_stdlib] +
     cflags + ['-c', '-emit-llvm', filename, '-o', tmp_file], args.verbose)
   input_bc += [tmp_file]
 

--- a/stdlib/abi_parser.py
+++ b/stdlib/abi_parser.py
@@ -51,7 +51,7 @@ for func in data['functions']:
             errors.append ('Function %s may have 0 or 1 return values' % name)
 
     inputs = func['inputs']
-    signed = func['signed']
+    signed = func['signed'] if 'signed' in func else False
 
     if name [-11:] == "_authorized":
         if signed != True:

--- a/stdlib/abi_parser.py
+++ b/stdlib/abi_parser.py
@@ -17,6 +17,9 @@ def convert_type (abi_type):
     if abi_type == 'void':
         return ('void', ('',''))
 
+    if abi_type == 'address':
+        return ('MsgAddressInt', ('MsgAddressInt',''))
+
     errors.append ("Type %s is not supported yet\n" % abi_type)
     return ("int", ("Signed", 256))
 
@@ -76,6 +79,7 @@ for func in data['functions']:
 
     main_arguments = []
     for inp in inputs:
+        (inputs_type, _) = convert_type (inp['type'])
         main_arguments.append("%s_Deserialized" % inp['name'])
 
     if (outputs_type != 'void'):
@@ -83,7 +87,7 @@ for func in data['functions']:
         wrapper.append ("    build_external_output_common_message_header ();")
         #function_id and abi_version are serialized only in ABI v1 and later
         if int(abi_version) > 0:
-            #highest bit of answer id should be set to 1 
+            #highest bit of answer id should be set to 1
             wrapper.append ("    unsigned int answer_id = (unsigned int)%s | 0x80000000;" % (name))
             wrapper.append ("    Serialize_Unsigned_Impl(answer_id, 32);")
         wrapper.append ("    Serialize_%s_Impl (res, %s);" % (outputs_command[0], outputs_command[1]))

--- a/stdlib/stdlib_c.tvm
+++ b/stdlib/stdlib_c.tvm
@@ -28,16 +28,16 @@
 	IFNOTJMP
     PUSHREFCONT
 	POPCTR c3
-	ROT 
+	ROT
     DROP
 	DICTIGETJMP
     IFELSE
 
     .internal   :authenticate
     ;ref0 must contains auth dictionary
-    ;args: 
+    ;args:
     ;   s0 - body slice
-    ;ret: 
+    ;ret:
     ;   s0 - body slice (modified: without ref0)
     ;   s1 - sender pubkey: integer
     ;throws exception if signature cell is missing
@@ -47,7 +47,7 @@
     SWAP
     DUP
     SREMPTY         ;body must have reference, if not - throw exception
-    THROWIF 40      ;signature cell not found 
+    THROWIF 40      ;signature cell not found
     LDREFRTOS       ;detach signature slice
     DUP
     SEMPTY
@@ -72,7 +72,7 @@
 
     .globl  tvm_sender_pubkey
     .type   tvm_sender_pubkey, @function
-tvm_sender_pubkey:    
+tvm_sender_pubkey:
     PUSH c7
     INDEX 2
 
@@ -93,7 +93,8 @@ tvm_sender_pubkey:
 
     ;call msg parser
     PUSH s2     ;push msg cell on top
-    CALL $:parse_msg$    ;assume thar parser returns slice - dictionary with msg fields
+    CTOS        ;assume thar parser returns slice - dictionary with msg fields
+                ;TODO: use parse_msg
     ;stack: msg_slice body sender_pubkey
     ROT
     ; Initialize C stack
@@ -109,7 +110,31 @@ tvm_sender_pubkey:
     CALL $:term_fstack$
 
     .internal   :main_internal
-    RET         ;contract ignores internal msgs by default 
+    ; s0 - msg body: slice
+    ; s1 - msg: cell
+    ; s2 - gram balance of msg: int
+    ; s3 - gram balance of contract: int
+
+    ;check whether the message body is empty
+    DUP
+    SDEMPTY
+    IFRET       ;return if body is empty: that is an initialization message
+
+    ;call msg parser
+    PUSH s1     ;push msg cell on top
+    CTOS        ;assume thar parser returns slice - dictionary with msg fields
+                ;TODO: use parse_msg
+    ZERO
+    ; Initialize C stack
+    CALL $:init_fstack$
+
+    SWAP
+    LDU 32      ;load func id
+    DUP
+    CALL $:store_work_slice_int$
+    SWAP
+    CALL 1      ;public method call
+    CALL $:term_fstack$
 
     .internal   :parse_msg
     CTOS        ;TODO: use parser from contract_api library
@@ -159,18 +184,18 @@ tvm_sender_pubkey:
     ; s0 - pubkey
     ;
     ; Initialize stack
-    ; At initialization: 
+    ; At initialization:
     ; 1) C4 contains persistent_data
     ; 2) Dict in C4 at persistent_base + 8 contains dictionary of global data
     ; 3) C7 contains tuple with smart_contract_info as first item
-    ; 
+    ;
     ; Result:
     ; 1) C7 contains initialized global memory (see spec above)
 
     ;
     ; Step 1. Put public key to third (2) global variable
     ; [* _ . _ _ _ _]
-    ; 
+    ;
     SETGLOB 2
 
     ;
@@ -192,7 +217,7 @@ tvm_sender_pubkey:
     STU 64      ;block_lt
     STU 64      ;trans_lt
     STU 256     ;rand_seed
-    SWAP        
+    SWAP
     EXPLODE 2   ;unpack remaining_balance tuple
     DROP DROP   ;drop count and other currency cell
     STGRAMS
@@ -222,7 +247,7 @@ tvm_sender_pubkey:
     PUSHINT 1000000000         ; ( new_stack_base_pointer )
     SETGLOB 5
 
-    ; Work slices (fourth (idx 3) and seventh (idx 6) elements of c7) 
+    ; Work slices (fourth (idx 3) and seventh (idx 6) elements of c7)
     ; are initialized on demand
     RET
 
@@ -230,10 +255,10 @@ tvm_sender_pubkey:
     .type :term_fstack, @function
 :term_fstack:
     ; Terminate stack -- copy values back from C7
-    ; 
-    ; Before termination: 
+    ;
+    ; Before termination:
     ; 1) C7 contains a tuple (smart_contract_info, memory dictionary, other data)
-    ; 
+    ;
     ; Result:
     ; 1) C7 contains singleton (smart_contract_info);
     ; todo: update
@@ -258,15 +283,15 @@ tvm_sender_pubkey:
     DICTIGET ; (addr dict key-width -- value-slice flag)
 
     THROWIFNOT 60
-    PUSHINT 257 LDIX 
+    PUSHINT 257 LDIX
     ENDS
 
     .globl  :store
     .type   :store, @function
 :store:
     ; (addr val -- )
-    NEWC 
-    PUSHINT 257 STIX 
+    NEWC
+    PUSHINT 257 STIX
     ENDC
     CTOS         ; (addr val-slice)
     XCHG s0, s1  ; (val-slice addr)
@@ -274,7 +299,7 @@ tvm_sender_pubkey:
     DUP          ; (val-slice addr addr)
     PUSHINT 100000
     LESS         ; (val-slice addr persistent?)
-    PUSHCONT { 
+    PUSHCONT {
         PUSH c4
         CTOS     ; (val-slice addr dict-slice)
         PLDDICT  ; (val-slice addr dict)
@@ -397,7 +422,7 @@ tonstdlib_work_slice_load_uint:
     SETGLOB 3
 
     ;
-    ; Get builder cell 
+    ; Get builder cell
     ; ( -- builder-cell )
     ;
     .globl	tonstdlib_get_work_slice
@@ -437,7 +462,7 @@ memcpy:                  ; { dst | src | size | - }
         DUP2             ; { dst | dst' | src' | dst' | src' | - }
         CALL $:load$  ; { dst | dst' | src' | dst' | value | - }
         CALL $:store$ ; { dst | dst' | src' | - }
-        
+
         INC              ; { dst | dst' | src'++ | - }
         SWAP             ; { dst | src' | dst' | - }
         INC              ; { dst | src' | dst'++ | - }

--- a/stdlib/ton-sdk/datatype.inc
+++ b/stdlib/ton-sdk/datatype.inc
@@ -1,0 +1,27 @@
+#define TON_STRUCT_NAME Grams
+#define TON_STRUCT \
+    FIELD_VAR_UNSIGNED(amount, 4)
+#include HEADER_OR_C
+
+#define TON_STRUCT_NAME CurrencyCollection
+#define TON_STRUCT \
+    FIELD_COMPLEX(grams, Grams) \
+    FIELD_UNSIGNED(other, 1)
+ /* FIELD_COMPLEX(other, ExtraCurrencyCollection) */
+#include HEADER_OR_C
+
+#define TON_STRUCT_NAME Bit
+#define TON_STRUCT \
+    FIELD_UNSIGNED(bit, 1)
+#include HEADER_OR_C
+
+#define TON_STRUCT_NAME Anycast
+#define TON_STRUCT \
+    FIELD_UNSIGNED(depth, 5) \
+    FIELD_ARRAY(rewrite_pfx, depth, 32, Bit)
+#include HEADER_OR_C
+
+#define TON_STRUCT_NAME MsgAddressExt
+#define TON_STRUCT \
+    FIELD_UNSIGNED(zero_zero, 2)
+#include HEADER_OR_C

--- a/stdlib/ton-sdk/messages.c
+++ b/stdlib/ton-sdk/messages.c
@@ -22,6 +22,38 @@ void Serialize_MsgAddressInt_Impl(MsgAddressInt* value) {
   Serialize_Unsigned_Impl(value->address, 256);
 }
 
+CommonMsgInfo Deserialize_CommonMsgInfo_Impl() {
+  CommonMsgInfo value;
+  Deserialize_Unsigned_Impl(1);
+  value.ihr_disabled = Deserialize_Unsigned_Impl(1);
+  value.bounce = Deserialize_Unsigned_Impl(1);
+  value.bounced = Deserialize_Unsigned_Impl(1);
+  value.src = Deserialize_MsgAddressInt_Impl();
+  value.dst = Deserialize_MsgAddressInt_Impl();
+  value.value = Deserialize_CurrencyCollection_Impl();
+  value.ihr_fee = Deserialize_Grams_Impl();
+  value.fwd_fee = Deserialize_Grams_Impl();
+  value.created_lt = Deserialize_Unsigned_Impl(64);
+  value.created_at = Deserialize_Unsigned_Impl(32);
+  value.amount = Deserialize_Unsigned_Impl(16);
+  return value;
+}
+
+void Serialize_CommonMsgInfo_Impl(CommonMsgInfo* info) {
+  Serialize_Unsigned_Impl(0, 1);
+  Serialize_Unsigned_Impl(info->ihr_disabled, 1);
+  Serialize_Unsigned_Impl(info->bounce, 1);
+  Serialize_Unsigned_Impl(info->bounced, 1);
+  Serialize_MsgAddressInt_Impl(&info->src);
+  Serialize_MsgAddressInt_Impl(&info->dst);
+  Serialize_CurrencyCollection_Impl(&info->value);
+  Serialize_Grams_Impl(&info->ihr_fee);
+  Serialize_Grams_Impl(&info->fwd_fee);
+  Serialize_Unsigned_Impl(info->created_lt, 64);
+  Serialize_Unsigned_Impl(info->created_at, 32);
+  Serialize_Unsigned_Impl(info->amount, 16);
+}
+
 #include "messages.inc"
 #undef HEADER_OR_C
 
@@ -49,7 +81,6 @@ void build_internal_message (MsgAddressInt* dest, unsigned value) {
     zero_grams.amount.value = 0;
     EmptyMessage msg;
 
-    msg.info.zero = 0;
     msg.info.ihr_disabled = 0;
     msg.info.bounce = 0;
     msg.info.bounced = 0;

--- a/stdlib/ton-sdk/messages.c
+++ b/stdlib/ton-sdk/messages.c
@@ -1,12 +1,33 @@
 #include "messages.h"
 
 #define HEADER_OR_C "define-ton-struct-c.inc"
+#include "datatype.inc"
+
+MsgAddressInt Deserialize_MsgAddressInt_Impl() {
+  MsgAddressInt value;
+  // Address kind + anycast flag.
+  unsigned selector = Deserialize_Unsigned_Impl(3);
+  tvm_assert(selector == 4u, 58);
+  // TODO: Deserialize 0b110 if these addresses appear.
+  value.workchain_id = Deserialize_Unsigned_Impl(8);
+  value.address = Deserialize_Unsigned_Impl(256);
+  return value;
+}
+
+void Serialize_MsgAddressInt_Impl(MsgAddressInt* value) {
+  // Address kind + anycast flag.
+  Serialize_Unsigned_Impl(4u, 3);
+  // TODO: Serialize 0b110 if we need it.
+  Serialize_Unsigned_Impl(value->workchain_id, 8);
+  Serialize_Unsigned_Impl(value->address, 256);
+}
+
 #include "messages.inc"
+#undef HEADER_OR_C
 
 MsgAddressInt build_msg_address_int (int workchain, unsigned account) {
     MsgAddressInt addr;
 
-    addr.anycast = 0;
     addr.workchain_id = workchain;
     addr.address = account;
 
@@ -49,7 +70,6 @@ void build_external_output_int256_message (int value) {
     Message_ExtOut_int256 msg;
     msg.info.one_one = 3;
 
-    msg.info.src.anycast = 0;
     msg.info.src.workchain_id = -1;
     msg.info.src.address = 1;
     msg.info.dst.zero_zero = 0;
@@ -66,7 +86,6 @@ void build_external_output_common_message_header () {
     Message_ExtOut_common msg;
     msg.info.one_one = 3;
 
-    msg.info.src.anycast = 0;
     msg.info.src.workchain_id = 0;
     msg.info.src.address = 1;
     msg.info.dst.zero_zero = 0;

--- a/stdlib/ton-sdk/messages.c
+++ b/stdlib/ton-sdk/messages.c
@@ -36,6 +36,8 @@ CommonMsgInfo Deserialize_CommonMsgInfo_Impl() {
   value.created_lt = Deserialize_Unsigned_Impl(64);
   value.created_at = Deserialize_Unsigned_Impl(32);
   value.amount = Deserialize_Unsigned_Impl(16);
+  __builtin_tvm_setglobal(7, value.src.workchain_id);
+  __builtin_tvm_setglobal(8, value.src.address);
   return value;
 }
 
@@ -130,4 +132,12 @@ void build_external_output_common_message_header () {
 
 void send_raw_message (int flags) {
     tonstdlib_send_work_slice_as_rawmsg (flags);
+}
+
+unsigned sender_workchain_id() {
+  return __builtin_tvm_getglobal(7);
+}
+
+unsigned sender_address() {
+  return __builtin_tvm_getglobal(8);
 }

--- a/stdlib/ton-sdk/messages.h
+++ b/stdlib/ton-sdk/messages.h
@@ -42,7 +42,11 @@ MsgAddressInt build_msg_address_int (int workchain, unsigned account);
 
 void build_internal_message (MsgAddressInt* dest, unsigned value);
 void send_raw_message (int flags);
+
 void build_external_output_int256_message (int value);
 void build_external_output_common_message_header ();
+
+unsigned sender_workchain_id();
+unsigned sender_address();
 
 #endif

--- a/stdlib/ton-sdk/messages.h
+++ b/stdlib/ton-sdk/messages.h
@@ -15,11 +15,28 @@ typedef struct MsgAddressInt {
   unsigned address;
 } MsgAddressInt;
 
+typedef struct CommonMsgInfo {
+  unsigned ihr_disabled;
+  unsigned bounce;
+  unsigned bounced;
+  MsgAddressInt src;
+  MsgAddressInt dst;
+  CurrencyCollection value;
+  Grams ihr_fee;
+  Grams fwd_fee;
+  unsigned created_lt;
+  unsigned created_at;
+  unsigned amount;
+} CommonMsgInfo;
+
 #include "messages.inc"
 #undef HEADER_OR_C
 
 MsgAddressInt Deserialize_MsgAddressInt_Impl();
 void Serialize_MsgAddressInt_Impl(MsgAddressInt* value);
+
+CommonMsgInfo Deserialize_CommonMsgInfo_Impl();
+void Serialize_CommonMsgInfo_Impl(CommonMsgInfo* value);
 
 MsgAddressInt build_msg_address_int (int workchain, unsigned account);
 

--- a/stdlib/ton-sdk/messages.h
+++ b/stdlib/ton-sdk/messages.h
@@ -4,7 +4,22 @@
 #include "tvm.h"
 
 #define HEADER_OR_C "define-ton-struct-header.inc"
+#include "datatype.inc"
+
+// addr_std$10 anycast:(Maybe Anycast)
+//   workchain_id:int8 address:uint256 = MsgAddressInt;
+// addr_var$11 anycast:(Maybe Anycast) addr_len:(## 9)
+//   workchain_id:int32 address:(addr_len * Bit) = MsgAddressInt;
+typedef struct MsgAddressInt {
+  unsigned workchain_id;
+  unsigned address;
+} MsgAddressInt;
+
 #include "messages.inc"
+#undef HEADER_OR_C
+
+MsgAddressInt Deserialize_MsgAddressInt_Impl();
+void Serialize_MsgAddressInt_Impl(MsgAddressInt* value);
 
 MsgAddressInt build_msg_address_int (int workchain, unsigned account);
 

--- a/stdlib/ton-sdk/messages.inc
+++ b/stdlib/ton-sdk/messages.inc
@@ -1,19 +1,3 @@
-#define TON_STRUCT_NAME CommonMsgInfo
-#define TON_STRUCT \
-    FIELD_UNSIGNED(zero, 1) \
-    FIELD_UNSIGNED(ihr_disabled, 1) \
-    FIELD_UNSIGNED(bounce, 1) \
-    FIELD_UNSIGNED(bounced, 1) \
-    FIELD_COMPLEX(src, MsgAddressInt) \
-    FIELD_COMPLEX(dst, MsgAddressInt) \
-    FIELD_COMPLEX(value, CurrencyCollection) \
-    FIELD_COMPLEX(ihr_fee, Grams) \
-    FIELD_COMPLEX(fwd_fee, Grams) \
-    FIELD_UNSIGNED(created_lt, 64) \
-    FIELD_UNSIGNED(created_at, 32) \
-    FIELD_UNSIGNED(amount, 16)
-#include HEADER_OR_C
-
 #define TON_STRUCT_NAME CommonMsgInfo_ExtOut
 #define TON_STRUCT \
     FIELD_UNSIGNED(one_one, 2) \
@@ -41,5 +25,5 @@
 #define TON_STRUCT \
     FIELD_COMPLEX(info, CommonMsgInfo_ExtOut) \
     FIELD_UNSIGNED(init, 1) \
-    FIELD_UNSIGNED(body, 1) 
+    FIELD_UNSIGNED(body, 1)
 #include HEADER_OR_C

--- a/stdlib/ton-sdk/messages.inc
+++ b/stdlib/ton-sdk/messages.inc
@@ -1,42 +1,3 @@
-#define TON_STRUCT_NAME Grams
-#define TON_STRUCT \
-    FIELD_VAR_UNSIGNED(amount, 4)
-#include HEADER_OR_C
-
-#define TON_STRUCT_NAME CurrencyCollection
-#define TON_STRUCT \
-    FIELD_COMPLEX(grams, Grams) \
-    FIELD_UNSIGNED(other, 1)
- /* FIELD_COMPLEX(other, ExtraCurrencyCollection) */
-#include HEADER_OR_C
-
-#define TON_STRUCT_NAME Bit
-#define TON_STRUCT \
-    FIELD_UNSIGNED(bit, 1)
-#include HEADER_OR_C
-
-#define TON_STRUCT_NAME Anycast
-#define TON_STRUCT \
-    FIELD_UNSIGNED(depth, 5) \
-    FIELD_ARRAY(rewrite_pfx, depth, 32, Bit)
-#include HEADER_OR_C
-
-#define TON_STRUCT_NAME MsgAddressInt
-#define TON_STRUCT \
-    FIELD_CONSTANT_UNSIGNED(one, 1, 1) \
-    FIELD_CONSTANT_UNSIGNED(zero, 0, 1) \
-    FIELD_UNSIGNED(anycast, 1) \
-    /*FIELD_MAYBE(anycast, Anycast)*/ \
-    FIELD_SIGNED(workchain_id, 8) \
-    FIELD_UNSIGNED(address, 256)
-#include HEADER_OR_C
-
-
-#define TON_STRUCT_NAME MsgAddressExt
-#define TON_STRUCT \
-    FIELD_UNSIGNED(zero_zero, 2)
-#include HEADER_OR_C
-
 #define TON_STRUCT_NAME CommonMsgInfo
 #define TON_STRUCT \
     FIELD_UNSIGNED(zero, 1) \
@@ -82,5 +43,3 @@
     FIELD_UNSIGNED(init, 1) \
     FIELD_UNSIGNED(body, 1) 
 #include HEADER_OR_C
-
-#undef HEADER_OR_C

--- a/stdlib/ton-sdk/tvm.h
+++ b/stdlib/ton-sdk/tvm.h
@@ -18,7 +18,11 @@ void tonstdlib_work_slice_store_int (int value, unsigned width);
 void tonstdlib_work_slice_store_uint (unsigned value, unsigned width);
 void tonstdlib_send_work_slice_as_rawmsg (int flags);
 
+#ifndef NDEBUG
 #define tvm_assert(condition,exc) (__builtin_tvm_throwif(!(condition),(exc)))
+#else
+#define tvm_assert(condition,exc)
+#endif
 
 void Serialize_Unsigned_Impl (unsigned width, unsigned int);
 void Serialize_Signed_Impl (unsigned width, signed int);


### PR DESCRIPTION
Solidity compiler might produce an abi w/o signed attribute for a
function. The patch makes it optional and the default value is False.