### PR TITLE
Emit C string literals as [n x i257] constant arrays

### DIFF
--- a/llvm/test/CodeGen/TVM/logstr.ll
+++ b/llvm/test/CodeGen/TVM/logstr.ll
@@ -6,15 +6,14 @@ target triple = "tvm"
 declare void @llvm.tvm.logstr(i257*) #1
 declare void @llvm.tvm.printstr(i257*) #1
 
-@.str = private unnamed_addr constant [22 x i8] c"123456789098765432123\00", align 1
+@.str = private unnamed_addr constant [22 x i257] [i257 49, i257 50, i257 51, i257 52, i257 53, i257 54, i257 55, i257 56, i257 57, i257 48, i257 57, i257 56, i257 55, i257 54, i257 53, i257 52, i257 51, i257 50, i257 49, i257 50, i257 51, i257 0], align 1
 
 ; CHECK-LABEL: test_logstr
 define void @test_logstr(i257 %x) {
 ; CHECK: LOGSTR test_logstr
 ; CHECK: LOGSTR 123456789098765
-  %ptr = getelementptr inbounds [22 x i8], [22 x i8]* @.str, i257 0, i257 0
-  %ptr257 = bitcast i8* %ptr to i257*
-  tail call void @llvm.tvm.logstr(i257* %ptr257)
+  %ptr = getelementptr inbounds [22 x i257], [22 x i257]* @.str, i257 0, i257 0
+  tail call void @llvm.tvm.logstr(i257* %ptr)
   ret void
 }
 
@@ -22,9 +21,7 @@ define void @test_logstr(i257 %x) {
 define void @test_printstr(i257 %x) {
 ; CHECK: LOGSTR test_printstr
 ; CHECK: PRINTSTR 123456789098765
-  %ptr = getelementptr inbounds [22 x i8], [22 x i8]* @.str, i257 0, i257 0
-  %ptr257 = bitcast i8* %ptr to i257*
-  tail call void @llvm.tvm.printstr(i257* %ptr257)
+  %ptr = getelementptr inbounds [22 x i257], [22 x i257]* @.str, i257 0, i257 0
+  tail call void @llvm.tvm.printstr(i257* %ptr)
   ret void
 }
-

--- a/llvm/tools/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/llvm/tools/clang/lib/CodeGen/CodeGenModule.cpp
@@ -4205,6 +4205,21 @@ llvm::Constant *
 CodeGenModule::GetConstantArrayFromStringLiteral(const StringLiteral *E) {
   assert(!E->getType()->isPointerType() && "Strings are always arrays");
 
+  if (getTriple().getArch() == llvm::Triple::tvm) {
+    auto *ATy = cast<llvm::ArrayType>(getTypes().ConvertType(E->getType()));
+    llvm::Type *ETy = ATy->getElementType();
+    unsigned NumElements = ATy->getNumElements();
+
+    SmallVector<llvm::Constant *, 32> Array;
+    Array.reserve(NumElements);
+    for (unsigned i = 0, e = E->getLength(); i != e; ++i)
+      Array.push_back(llvm::ConstantInt::get(ETy, E->getCodeUnit(i)));
+    Array.push_back(llvm::ConstantInt::get(ETy, 0));
+    Array.resize(NumElements);
+
+    return llvm::ConstantArray::get(ATy, Array);
+  }
+
   // Don't emit it as the address of the string, emit the string data itself
   // as an inline array.
   if (E->getCharByteWidth() == 1) {

--- a/llvm/tools/clang/test/CodeGen/tvm/string-literal.c
+++ b/llvm/tools/clang/test/CodeGen/tvm/string-literal.c
@@ -1,0 +1,5 @@
+// RUN: %clang -target tvm -S -emit-llvm %s -o - | FileCheck %s
+// REQUIRES: tvm-registered-target
+
+// CHECK: @.str = private unnamed_addr constant [4 x i257] [i257 98, i257 97, i257 114, i257 0], align 1
+char foo(int n) { return "bar"[n]; }

--- a/llvm/tools/llvm-mc-assemble-fuzzer/llvm-mc-assemble-fuzzer.cpp
+++ b/llvm/tools/llvm-mc-assemble-fuzzer/llvm-mc-assemble-fuzzer.cpp
@@ -25,7 +25,6 @@
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/MC/MCTargetOptionsCommandFlags.inc"
-#include "llvm/MC/MCObjectWriter.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/FileUtilities.h"
@@ -231,8 +230,7 @@ int AssembleOneInput(const uint8_t *Data, size_t Size) {
     MCCodeEmitter *CE = TheTarget->createMCCodeEmitter(*MCII, *MRI, Ctx);
     MCAsmBackend *MAB = TheTarget->createMCAsmBackend(*STI, *MRI, MCOptions);
     Str.reset(TheTarget->createMCObjectStreamer(
-        TheTriple, Ctx, std::unique_ptr<MCAsmBackend>(MAB),
-        MAB->createObjectWriter(*OS),
+        TheTriple, Ctx, std::unique_ptr<MCAsmBackend>(MAB), *OS,
         std::unique_ptr<MCCodeEmitter>(CE), *STI, MCOptions.MCRelaxAll,
         MCOptions.MCIncrementalLinkerCompatible,
         /*DWARFMustBeAtTheEnd*/ false));

--- a/llvm/tools/llvm-mc-assemble-fuzzer/llvm-mc-assemble-fuzzer.cpp
+++ b/llvm/tools/llvm-mc-assemble-fuzzer/llvm-mc-assemble-fuzzer.cpp
@@ -25,6 +25,7 @@
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/MC/MCTargetOptionsCommandFlags.inc"
+#include "llvm/MC/MCObjectWriter.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/FileUtilities.h"
@@ -230,7 +231,8 @@ int AssembleOneInput(const uint8_t *Data, size_t Size) {
     MCCodeEmitter *CE = TheTarget->createMCCodeEmitter(*MCII, *MRI, Ctx);
     MCAsmBackend *MAB = TheTarget->createMCAsmBackend(*STI, *MRI, MCOptions);
     Str.reset(TheTarget->createMCObjectStreamer(
-        TheTriple, Ctx, std::unique_ptr<MCAsmBackend>(MAB), *OS,
+        TheTriple, Ctx, std::unique_ptr<MCAsmBackend>(MAB),
+        MAB->createObjectWriter(*OS),
         std::unique_ptr<MCCodeEmitter>(CE), *STI, MCOptions.MCRelaxAll,
         MCOptions.MCIncrementalLinkerCompatible,
         /*DWARFMustBeAtTheEnd*/ false));


### PR DESCRIPTION
A C input
```
char foo(int n) { return "bar"[n]; }
```
gets translated to
```
@.str = private constant [4 x i257] [i257 98, i257 97, i257 114, i257 0], align 1

define signext i257 @foo(i257 %n) {
entry:
  %arrayidx = getelementptr inbounds [4 x i257], [4 x i257]* @.str, i257 0, i257 %n
  %0 = load i257, i257* %arrayidx, align 1, !tbaa !2
  ret i257 %0
}
```