### PR TITLE
Added tvm_raw_func attribute

### DIFF
--- a/llvm/include/llvm/CodeGen/AsmPrinter.h
+++ b/llvm/include/llvm/CodeGen/AsmPrinter.h
@@ -622,8 +622,12 @@ private:
   mutable unsigned LastFn = 0;
   mutable unsigned Counter = ~0U;
 
+  // TVM local begin
+protected:
   /// This method emits the header for the current function.
   virtual void EmitFunctionHeader();
+private:
+  // TVM local end
 
   /// Emit a blob of inline asm to the output streamer.
   void

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -1179,6 +1179,11 @@ void AsmPrinter::EmitFunctionBody() {
   // Emit target-specific gunk after the function body.
   EmitFunctionBodyEnd();
 
+  // TVM local begin
+  if (F.hasFnAttribute("tvm_raw_func"))
+    return;
+  // TVM local end
+
   if (needFuncLabelsForEHOrDebugInfo(*MF, MMI) ||
       MAI->hasDotTypeDotSizeDirective()) {
     // Create a symbol for the end of function.

--- a/llvm/lib/IR/Type.cpp
+++ b/llvm/lib/IR/Type.cpp
@@ -129,6 +129,15 @@ unsigned Type::getPrimitiveSizeInBits() const {
   case Type::X86_MMXTyID: return 64;
   case Type::IntegerTyID: return cast<IntegerType>(this)->getBitWidth();
   case Type::VectorTyID:  return cast<VectorType>(this)->getBitWidth();
+  // TVM local begin
+  // We don't model slice/builder/cell/tuple internal data.
+  // Just keep them as "handles", bitcast'able to i257, so bit size is 257.
+  case Type::TVMSliceID:
+  case Type::TVMBuilderID:
+  case Type::TVMCellID:
+  case Type::TVMTupleID:
+    return 257;
+  // TVM local end
   default: return 0;
   }
 }

--- a/llvm/lib/Target/TVM/TVMAsmPrinter.cpp
+++ b/llvm/lib/Target/TVM/TVMAsmPrinter.cpp
@@ -52,6 +52,8 @@ public:
   std::string regToString(const MachineOperand &MO);
   void EmitBasicBlockStart(const MachineBasicBlock &MBB) const override;
 
+  void EmitFunctionHeader() override;
+
   /// Print a big LLVM constant int (>64 bit) to the .s file.
   void EmitBigInt(const ConstantInt *CI) override;
 
@@ -219,6 +221,15 @@ void TVMAsmPrinter::EmitSubBlockForPushcont(const TVMMCInstLower &lower,
 
 void TVMAsmPrinter::EmitBasicBlockStart(const MachineBasicBlock &MBB) const {
   EmitBBEntry(MBB);
+}
+
+void TVMAsmPrinter::EmitFunctionHeader() {
+  const Function &F = MF->getFunction();
+  if (F.hasFnAttribute("tvm_raw_func")) {
+    OutStreamer->EmitRawText("\t.internal\t:" + CurrentFnSym->getName());
+  } else {
+    AsmPrinter::EmitFunctionHeader();
+  }
 }
 
 /// Print a big LLVM constant int (>64 bit) to the .s file.

--- a/llvm/lib/Target/TVM/TVMFrameLowering.cpp
+++ b/llvm/lib/Target/TVM/TVMFrameLowering.cpp
@@ -53,6 +53,10 @@ void TVMFrameLowering::emitPrologue(MachineFunction &MF,
   uint64_t StackSize = MFI.getStackSize();
   if (StackSize == 0 && !TraceCalls)
     return;
+  if (MF.getFunction().hasFnAttribute("tvm_raw_func") && StackSize) {
+    report_fatal_error("Raw function requires stack");
+    return;
+  }
 
   auto InsertPt =
       llvm::find_if(MBB, [&](auto &pt) { return !TVM::isArgument(pt); });

--- a/llvm/tools/clang/include/clang/Basic/Attr.td
+++ b/llvm/tools/clang/include/clang/Basic/Attr.td
@@ -1650,6 +1650,11 @@ def TVMTupleStruct : InheritableAttr {
   let Documentation = [Undocumented];
   let MeaningfulToClassTemplateDefinition = 1;
 }
+def TVMRawFunc : Attr {
+  let Spellings = [Clang<"tvm_raw_func">];
+  let Documentation = [Undocumented];
+  let Subjects = SubjectList<[Function]>;
+}
 // TVM local end
 
 def ObjCPreciseLifetime : InheritableAttr {

--- a/llvm/tools/clang/lib/AST/ItaniumMangle.cpp
+++ b/llvm/tools/clang/lib/AST/ItaniumMangle.cpp
@@ -604,6 +604,11 @@ bool ItaniumMangleContextImpl::shouldMangleCXXName(const NamedDecl *D) {
     if (FD->isMSVCRTEntryPoint())
       return false;
 
+    // TVM local begin
+    if (FD->hasAttr<TVMRawFuncAttr>())
+      return false;
+    // TVM local end
+
     // C++ functions and those whose names are not a simple identifier need
     // mangling.
     if (!FD->getDeclName().isIdentifier() || L == CXXLanguageLinkage)

--- a/llvm/tools/clang/lib/CodeGen/TargetInfo.cpp
+++ b/llvm/tools/clang/lib/CodeGen/TargetInfo.cpp
@@ -840,6 +840,16 @@ class TVMTargetCodeGenInfo final : public TargetCodeGenInfo {
 public:
   explicit TVMTargetCodeGenInfo(CodeGen::CodeGenTypes &CGT)
       : TargetCodeGenInfo(new TVMABIInfo(CGT)) {}
+
+  void setTargetAttributes(const Decl *D, llvm::GlobalValue *GV,
+                           CodeGen::CodeGenModule &CGM) const override {
+    if (auto *FD = dyn_cast_or_null<FunctionDecl>(D)) {
+      if (FD->hasAttr<TVMRawFuncAttr>()) {
+        llvm::Function *Fn = cast<llvm::Function>(GV);
+        Fn->addFnAttr("tvm_raw_func");
+      }
+    }
+  }
 };
 
 /// Classify argument of given type \p Ty.

--- a/llvm/tools/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/llvm/tools/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6379,6 +6379,9 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
     handleSimpleAttribute<TVMTupleStructAttr>(S, D, AL);
     D->setLiteral();
     break;
+  case ParsedAttr::AT_TVMRawFunc:
+    handleSimpleAttribute<TVMRawFuncAttr>(S, D, AL);
+    break;
   case ParsedAttr::AT_Blocks:
     handleBlocksAttr(S, D, AL);
     break;

--- a/llvm/tools/clang/test/CodeGen/tvm/test_union_with_bool.cpp
+++ b/llvm/tools/clang/test/CodeGen/tvm/test_union_with_bool.cpp
@@ -1,0 +1,85 @@
+// RUN: %clang -O3 -S -c -emit-llvm -std=c++17 -target tvm %s -o - | FileCheck %s
+// REQUIRES: tvm-registered-target
+
+struct most_big {
+  int a_v0;
+  bool a_v1_bool;
+  unsigned a_v2;
+  __tvm_slice a_v3;
+  __tvm_builder a_v4;
+  __tvm_cell a_v5;
+  __tvm_tuple a_v6;
+  unsigned a_v7;
+  int a_v8;
+};
+
+struct beta {
+  int b_v0;
+  int b_v1;
+  unsigned b_v2;
+};
+
+struct gamma {
+  int g_v0;
+  unsigned g_v1;
+  unsigned g_v2;
+  int g_v3;
+};
+
+struct delta {
+  int d_v0;
+  __tvm_slice d_v1;
+};
+
+union test_union {
+  gamma g;
+  beta b;
+  most_big a;
+  delta d;
+};
+
+// CHECK: @_Z18test_argument_beta10test_union(i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}})
+__attribute__((noinline)) int test_argument_beta(test_union v) {
+  return v.b.b_v0 + v.b.b_v1 + (int)v.b.b_v2;
+}
+
+// CHECK: @_Z19test_argument_gamma10test_union(i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}})
+__attribute__((noinline)) int test_argument_gamma(test_union v) {
+  return v.g.g_v0 + (int)v.g.g_v1 + (int)v.g.g_v2 + v.g.g_v3;
+}
+
+// CHECK: @_Z19test_argument_delta10test_union(i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}})
+__attribute__((noinline)) int test_argument_delta(test_union v) {
+  auto [val, new_sl] = __builtin_tvm_ldu(v.d.d_v1, 8);
+  return v.d.d_v0 + val;
+}
+
+int test_argument_beta_call() {
+  test_union v;
+  beta b = { 111, 222, 333 };
+  v.b = b;
+  // CHECK: call i257 @_Z18test_argument_beta10test_union(i257 111, i257 222, i257 333
+  return test_argument_beta(v);
+}
+
+int test_argument_gamma_call() {
+  test_union v;
+  gamma g = { 111, 222, 333, 444 };
+  v.g = g;
+  // CHECK: call i257 @_Z19test_argument_gamma10test_union(i257 111, i257 222, i257 333, i257 444
+  return test_argument_gamma(v);
+}
+
+int test_argument_delta_call(__tvm_slice sl) {
+  test_union v;
+  delta d = { 111, sl };
+  v.d = d;
+  // CHECK: call i257 @_Z19test_argument_delta10test_union(i257 111, i257 %0
+  return test_argument_delta(v);
+}
+
+// most_big structure test
+int test_most_big(test_union v) {
+  return v.a.a_v1_bool ? v.a.a_v0 : v.a.a_v8;
+}
+

--- a/stdlib/stdlib_cpp.tvm
+++ b/stdlib/stdlib_cpp.tvm
@@ -1,0 +1,39 @@
+    .internal-alias :main_external,     -1
+    .internal-alias :main_internal,     0
+    .internal-alias :general_purpose,   1
+
+; ======================================================
+; Part 1. Initialization and termination of the contract
+; ======================================================
+
+    .selector
+    ; s0 - func_id
+    ; s1.. - other data
+    SETCP0
+    PUSHREFSLICE        ; dictionary of methods in first reference
+    PLDDICT
+    OVER
+    NEQINT 1
+    PUSHCONT {          ; if func_id negative or zero - direct call to method
+        PUSHINT 32
+        DICTIGETJMP     ; execute method and return
+    }
+    PUSHCONT {          ; get dictionary with methods
+        PUSHINT 32
+        DICTIGET
+        THROWIFNOT 52   ; no dictionary of methods
+        PLDDICT
+        PUSHINT 32
+        DICTUGETJMP     ; execute method and return
+        THROW 51
+    }
+    IFELSE
+
+; ==========================================
+; Part 2. C-specific functionality (runtime)
+; ==========================================
+
+; Global variables allocation (allocation of C7 tuple cells)
+; GLOB 0 (FIRST)  -- Smart contract info
+; GLOB 1 (SECOND) -- Global variables dictionary
+


### PR DESCRIPTION
Dependent from https://github.com/tonlabs/TON-Compiler/pull/36.
Added tvm_raw_func attribute.
For main_external, main_internal, main_ticktock, main_split, main_merge functions.
And for utility system functions.
Generates `.internal` for such functions in assembly.
And c++ mangling is not used for the functions.