### PR TITLE
Add intrinsic to access stack otherwise unavailable

### DIFF
--- a/llvm/include/llvm/IR/IntrinsicsTVM.td
+++ b/llvm/include/llvm/IR/IntrinsicsTVM.td
@@ -244,7 +244,7 @@ let TargetPrefix = "tvm" in {
     GCCBuiltin<"__builtin_tvm_div">,
     Intrinsic<[llvm_i257_ty], [llvm_i257_ty, llvm_i257_ty],
               [IntrNoMem]>;
-  
+
   def int_tvm_mod :
     GCCBuiltin<"__builtin_tvm_mod">,
     Intrinsic<[llvm_i257_ty], [llvm_i257_ty, llvm_i257_ty],
@@ -481,4 +481,8 @@ let TargetPrefix = "tvm" in {
   foreach i = 1-255 in
   def int_tvm_unpackfirst#i : GCCBuiltin<"__builtin_tvm_unpackfirst"#i>,
     Intrinsic<!listsplat(llvm_i257_ty, i), [llvm_TVMTuple_ty], [IntrNoMem]>;
+
+  def int_tvm_hiddenstack :
+    GCCBuiltin<"__builtin_tvm_hiddenstack">,
+    Intrinsic<[llvm_i257_ty], [llvm_i257_ty], [IntrNoMem]>;
 }

--- a/llvm/lib/Target/TVM/TVMInstrInfo.td
+++ b/llvm/lib/Target/TVM/TVMInstrInfo.td
@@ -239,6 +239,9 @@ defm PU2XC : SI<(ins stack_op:$i, stack_op:$j, stack_op:$k),
 defm PUSH3 : SI<(ins stack_op:$i, stack_op:$j, stack_op:$k),
                 "PUSH3\t$i, $j, $k", 0x547>;
 
+let isPseudo=1 in
+def HIDDENSTACK : NI<(outs I257:$dst), (ins uimm8:$src), [(set I257:$dst, (int_tvm_hiddenstack uimm8:$src))], 1>;
+
 defm POP  : SI<(ins stack_op:$dst), "POP\t$dst", 0x30>;
 defm DROP : SI<(ins), "DROP", 0x30>;
 defm BLKDROP : SI<(ins uimm8:$sz), "BLKDROP\t$sz", 0x5F0>;
@@ -341,7 +344,6 @@ def : IntDivPat<srem, MOD>;
 //===----------------------------------------------------------------------===//
 def chkbool : PatFrag<(ops node:$in), (int_tvm_fitsx node:$in, 1)>;
 def chkbit  : PatFrag<(ops node:$in), (int_tvm_ufitsx node:$in, 1)>;
-
 let hasSideEffects = 1 in {
   defm FITSX   : BinaryRR<int_tvm_fitsx, "FITSX", 0xb600>;
   defm UFITSX  : BinaryRR<int_tvm_ufitsx, "UFITSX", 0xb601>;

--- a/llvm/lib/Target/TVM/TVMStack.cpp
+++ b/llvm/lib/Target/TVM/TVMStack.cpp
@@ -147,6 +147,7 @@ Stack& Stack::operator += (const StackFixup::Change &change) {
         std::swap(Data[v.i], Data[v.j]);
       },
       [this](StackFixup::pushI v){ Data.push_front(Data[v.i]); },
+      [    ](StackFixup::pushHidden v){ },
       [this](StackFixup::pushUndef){
         Data.push_front(StackVreg(TVMFunctionInfo::UnusedReg));
       },

--- a/llvm/lib/Target/TVM/TVMStackFixup.cpp
+++ b/llvm/lib/Target/TVM/TVMStackFixup.cpp
@@ -453,6 +453,14 @@ StackFixup StackFixup::DiffForArgs(const Stack &From, const MIArgs &Args,
   return rv;
 }
 
+StackFixup StackFixup::DiffForHiddenStack(const Stack &Src, size_t Element,
+                                          unsigned OutRegister) {
+  Stack CurrentStack(Src);
+  StackFixup rv;
+  rv(CurrentStack += rv(pushHidden(Src.size() + Element, OutRegister)));
+  return rv;
+}
+
 void StackFixup::apply(Stack &stack) const {
   for (auto p : Changes)
     stack += p.first;
@@ -587,6 +595,7 @@ void StackFixup::printElem(raw_ostream &OS, const Change &change) const {
           [&](xchgTop v) { OS << "xchg s(" << v.i << ")"; },
           [&](xchg v) { OS << "xchg s(" << v.i << "), s(" << v.j << ")"; },
           [&](pushI v) { OS << "push s(" << v.i << ")"; },
+          [&](pushHidden v) { OS << "push s(" << v.i << ")"; },
           [&](pushUndef) { OS << "zero"; },
           [&](blkswap v) { OS << "blkswap " << v.deepSz << ", " << v.topSz; },
           [&](roll v) {

--- a/llvm/lib/Target/TVM/TVMStackFixup.h
+++ b/llvm/lib/Target/TVM/TVMStackFixup.h
@@ -63,6 +63,9 @@ public:
   static StackFixup DiffForArgs(const Stack &Src, const MIArgs &Args,
                                 bool IsCommutative = false);
 
+  static StackFixup DiffForHiddenStack(const Stack &Src, size_t Element,
+                                       unsigned OutRegister);
+
   void apply(Stack &stack) const;
 
   // Remove one copy of this elem
@@ -105,6 +108,12 @@ public:
       }
     }
     unsigned i;
+  };
+  struct pushHidden : pushI {
+    explicit pushHidden(unsigned i, unsigned reg, bool checkLimits = true)
+        : pushI(i, checkLimits), reg(reg) {}
+    unsigned i;
+    unsigned reg;
   };
   struct dup : pushI {
     dup() : pushI(0) {}
@@ -242,8 +251,8 @@ public:
         : tripleChange(true, true, false, i, j, k) {}
   };
   using Change =
-      std::variant<drop, nip, xchgTop, xchg, pushI, pushUndef, blkswap, blkdrop,
-                   roll, reverse, doubleChange, tripleChange>;
+      std::variant<drop, nip, xchgTop, xchg, pushI, pushHidden, pushUndef,
+                   blkswap, blkdrop, roll, reverse, doubleChange, tripleChange>;
   using ChangesVec = std::vector<std::pair<Change, std::string>>;
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
@@ -317,7 +326,7 @@ private:
     Changes.back().second = comment;
   }
   ChangesVec Changes;
-};
+}; // namespace llvm
 
 } // namespace llvm
 

--- a/llvm/lib/Target/TVM/TVMStackModel.cpp
+++ b/llvm/lib/Target/TVM/TVMStackModel.cpp
@@ -523,6 +523,15 @@ StackFixup TVMStackModel::prepareStackFor(MachineInstr &MI,
   if (MI.isImplicitDef())
     return {};
 
+  if (MI.getOpcode() == TVM::HIDDENSTACK) {
+    auto Result = MI.getOperand(0);
+    auto Operand = MI.getOperand(1);
+    assert(Result.isReg() && Operand.isCImm() && "Unexpected instruction format");
+    return StackFixup::DiffForHiddenStack(StackBefore,
+                                          Operand.getCImm()->getZExtValue(),
+                                          Result.getReg());
+  }
+
   auto *MBB = MI.getParent();
 
 #ifndef NDEBUG

--- a/llvm/test/CodeGen/TVM/hiddenstack.ll
+++ b/llvm/test/CodeGen/TVM/hiddenstack.ll
@@ -1,0 +1,27 @@
+; RUN: llc < %s -march=tvm | FileCheck %s
+target datalayout = "E-S257-i1:257:257-i8:257:257-i16:257:257-i32:257:257-i64:257:257-i257:257:257-p:257:257-a:257:257"
+target triple = "tvm"
+
+declare i257 @llvm.tvm.hiddenstack(i257 %index)
+
+; CHECK-LABEL: hstack:
+define i257 @hstack() nounwind {
+; CHECK: PUSH s1
+  %1 = call i257 @llvm.tvm.hiddenstack(i257 1)
+  ret i257 %1
+}
+
+; CHECK-LABEL: hstack_args:
+define i257 @hstack_args(i257 %a, i257 %b, i257 %c) nounwind {
+; CHECK: { %{{[0-9]+}} | %{{[0-9]+}} | %{{[0-9]+}} | - }
+; CHECK: PUSH s10
+; CHECK: { %{{[0-9]+}} | %{{[0-9]+}} | %{{[0-9]+}} | %{{[0-9]+}} | - }
+  %1 = call i257 @llvm.tvm.hiddenstack(i257 7)
+; CHECK: ADD
+; CHECK: ADD
+; CHECK: ADD
+  %2 = add i257 %1, %a
+  %3 = add i257 %2, %b
+  %4 = add i257 %3, %c
+  ret i257 %4
+}

--- a/llvm/tools/clang/include/clang/Basic/BuiltinsTVM.def
+++ b/llvm/tools/clang/include/clang/Basic/BuiltinsTVM.def
@@ -642,5 +642,6 @@ BUILTIN(__builtin_tvm_unpackfirst252, "T252Tt", "nc")
 BUILTIN(__builtin_tvm_unpackfirst253, "T253Tt", "nc")
 BUILTIN(__builtin_tvm_unpackfirst254, "T254Tt", "nc")
 BUILTIN(__builtin_tvm_unpackfirst255, "T255Tt", "nc")
+BUILTIN(__builtin_tvm_hiddenstack, "WiWi", "nc")
 
 #undef BUILTIN

--- a/stdlib/ton-sdk/smart-contract-info.c
+++ b/stdlib/ton-sdk/smart-contract-info.c
@@ -7,3 +7,11 @@ SmartContractInfo get_SmartContractInfo () {
 
 #define HEADER_OR_C "define-ton-struct-c.inc"
 #include "smart-contract-info.inc"
+
+unsigned contract_balance() {
+  return __builtin_tvm_hiddenstack(0);
+}
+
+unsigned message_balance() {
+  return __builtin_tvm_hiddenstack(1);
+}

--- a/stdlib/ton-sdk/smart-contract-info.h
+++ b/stdlib/ton-sdk/smart-contract-info.h
@@ -11,4 +11,7 @@ void tonstdlib_get_smart_contract_info();
 
 SmartContractInfo get_SmartContractInfo ();
 
+unsigned contract_balance();
+unsigned message_balance();
+
 #endif


### PR DESCRIPTION
When main_internal or main_external is called, contract and message
balances are located on stack. These values, however, are not accessible
in the stack model.
@llvm.tvm.hiddenstack(number) is to access values that resides in slots
that are not represented by stack model (e.g. hiddenstack(0) is the
contract balance, hiddenstack(2) is the incoming message balance).