### PR TITLE
Disable tail merging

### DIFF
--- a/llvm/lib/Target/TVM/TVMTargetMachine.cpp
+++ b/llvm/lib/Target/TVM/TVMTargetMachine.cpp
@@ -95,7 +95,9 @@ namespace {
 class TVMPassConfig : public TargetPassConfig {
 public:
   TVMPassConfig(TVMTargetMachine &TM, PassManagerBase &PM)
-      : TargetPassConfig(TM, PM) {}
+      : TargetPassConfig(TM, PM) {
+    EnableTailMerge = false;
+  }
 
   TVMTargetMachine &getTVMTargetMachine() const {
     return getTM<TVMTargetMachine>();

--- a/llvm/test/CodeGen/TVM/tail-merge-bug.ll
+++ b/llvm/test/CodeGen/TVM/tail-merge-bug.ll
@@ -1,0 +1,13 @@
+; RUN: llc -march=tvm < %s
+target datalayout = "E-S257-i1:257:257-i8:257:257-i16:257:257-i32:257:257-i64:257:257-i257:257:257-p:257:257-a:257:257"
+target triple = "tvm"
+
+define void @foo(i257 %v) {
+entry:
+  %cmp = icmp eq i257 %v, 0
+  br i1 %cmp, label %then, label %else
+then:
+  ret void
+else:
+  ret void
+}


### PR DESCRIPTION
The generic tail merging optimization (see lib/CodeGen/BranchFolding.cpp) is not aware of TVM control flow peculiarities and produces a broken output. This change disables it.

Fixes #52.