### PR TITLE
sizeof...(T) returns struct fields count for struct template arguments

### DIFF
--- a/llvm/tools/clang/include/clang/Sema/Sema.h
+++ b/llvm/tools/clang/include/clang/Sema/Sema.h
@@ -6844,6 +6844,11 @@ public:
   Optional<unsigned> getNumArgumentsInExpansion(QualType T,
       const MultiLevelTemplateArgumentList &TemplateArgs);
 
+  // TVM local begin
+  unsigned calcFieldCountForTrickySizeof(NamedDecl *Param,
+      const MultiLevelTemplateArgumentList &TemplateArgs);
+  // TVM local end
+
   /// Determine whether the given declarator contains any unexpanded
   /// parameter packs.
   ///

--- a/llvm/tools/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/llvm/tools/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -760,6 +760,12 @@ namespace {
                                                        NumExpansions);
     }
 
+    // TVM local begin
+    unsigned calcFieldCountForTrickySizeof(NamedDecl *Param) {
+      return getSema().calcFieldCountForTrickySizeof(Param, TemplateArgs);
+    }
+    // TVM local end
+
     void ExpandingFunctionParameterPack(ParmVarDecl *Pack) {
       SemaRef.CurrentInstantiationScope->MakeInstantiatedLocalArgPack(Pack);
     }

--- a/llvm/tools/clang/lib/Sema/SemaTemplateVariadic.cpp
+++ b/llvm/tools/clang/lib/Sema/SemaTemplateVariadic.cpp
@@ -814,6 +814,22 @@ Optional<unsigned> Sema::getNumArgumentsInExpansion(QualType T,
   return Result;
 }
 
+// TVM local begin
+unsigned Sema::calcFieldCountForTrickySizeof(
+    NamedDecl *Param,
+    const MultiLevelTemplateArgumentList &TemplateArgs) {
+  if (isa<ParmVarDecl>(Param))
+    return 0;
+  auto [Depth, Index] = getDepthAndIndex(Param);
+  const TemplateArgument &Arg = TemplateArgs(Depth, Index);
+  auto Ty = Arg.getAsType();
+  const auto *Rec = Ty->getAsStructureType();
+  if (!Rec)
+      return 0;
+  return llvm::count_if(Rec->getDecl()->fields(), [](auto){ return true; });
+}
+// TVM local end
+
 bool Sema::containsUnexpandedParameterPacks(Declarator &D) {
   const DeclSpec &DS = D.getDeclSpec();
   switch (DS.getTypeSpecType()) {
@@ -986,7 +1002,11 @@ ExprResult Sema::ActOnSizeofParameterPackExpr(Scope *S,
     return ExprError();
   }
 
-  if (!ParameterPack || !ParameterPack->isParameterPack()) {
+  // TVM local begin
+  if (!ParameterPack || (!ParameterPack->isParameterPack() &&
+      (ParameterPack->getKind() == Decl::NonTypeTemplateParm ||
+       !ParameterPack->isTemplateParameter()))) {
+    // TVM local end
     Diag(NameLoc, diag::err_sizeof_pack_no_pack_name)
       << &Name;
     return ExprError();

--- a/llvm/tools/clang/lib/Sema/TreeTransform.h
+++ b/llvm/tools/clang/lib/Sema/TreeTransform.h
@@ -261,6 +261,12 @@ public:
     return false;
   }
 
+  // TVM local begin
+  unsigned calcFieldCountForTrickySizeof(NamedDecl *Param) {
+    return 0;
+  }
+  // TVM local end
+
   /// "Forget" about the partially-substituted pack template argument,
   /// when performing an instantiation that must preserve the parameter pack
   /// use.
@@ -11422,6 +11428,20 @@ TreeTransform<Derived>::TransformSizeOfPackExpr(SizeOfPackExpr *E) {
 
   ArrayRef<TemplateArgument> PackArgs;
   TemplateArgument ArgStorage;
+
+  // TVM local begin
+  if (!E->getPack()->isParameterPack()) {
+    auto Sz = getDerived().calcFieldCountForTrickySizeof(E->getPack());
+    // auto *decl = getDerived().TransformDecl(E->getPackLoc(), E->getPack());
+    // auto *rec = dyn_cast<RecordDecl>(decl);
+    // if (!rec)
+    //   return E;
+    // auto Sz = llvm::count_if(rec->fields(), [](const auto&){ return true; });
+    return getDerived().RebuildSizeOfPackExpr(E->getOperatorLoc(), E->getPack(),
+                                              E->getPackLoc(),
+                                              E->getRParenLoc(), Sz, None);
+  }
+  // TVM local end
 
   // Find the argument list to transform.
   if (E->isPartiallySubstituted()) {

--- a/llvm/tools/clang/test/CodeGen/tvm/pack-sizeof-for-struct.cpp
+++ b/llvm/tools/clang/test/CodeGen/tvm/pack-sizeof-for-struct.cpp
@@ -1,0 +1,33 @@
+// RUN: %clang -O3 -S -c -emit-llvm -target tvm %s -o -
+// REQUIRES: tvm-registered-target
+
+template<class T>
+struct fields_count {
+  static constexpr unsigned value = sizeof...(T);
+};
+
+template<class T>
+static constexpr unsigned fields_count_v = fields_count<T>::value;
+
+struct test_struct_a {
+  int a;
+  unsigned b;
+  struct internal { int x; int y; } c;
+  int d;
+};
+
+struct test_struct_b {
+  int a;
+  int b;
+};
+
+struct test_struct_c {
+};
+
+int foo() {
+  static_assert(fields_count_v<test_struct_a> == 4);
+  static_assert(fields_count_v<test_struct_b> == 2);
+  static_assert(fields_count_v<test_struct_c> == 0);
+  return 0;
+}
+


### PR DESCRIPTION
It is needed for generation of parsers/builders for message formats declared as structure.
