### PR TITLE
Conditional select supported for tvm builtin types

### DIFF
--- a/llvm/lib/Target/TVM/TVMISelLowering.cpp
+++ b/llvm/lib/Target/TVM/TVMISelLowering.cpp
@@ -121,8 +121,13 @@ TVMTargetLowering::TVMTargetLowering(const TargetMachine &TM,
   setTargetDAGCombine(ISD::ANY_EXTEND);
 
   // Expand these forms; we pattern-match the forms that we can handle in isel.
-  for (auto Op : {ISD::BR_CC, ISD::SELECT_CC})
+  for (auto Op : {ISD::BR_CC, ISD::SELECT_CC}) {
     setOperationAction(Op, MVT::i257, Expand);
+    setOperationAction(Op, MVT::TVMTuple, Expand);
+    setOperationAction(Op, MVT::TVMSlice, Expand);
+    setOperationAction(Op, MVT::TVMBuilder, Expand);
+    setOperationAction(Op, MVT::TVMCell, Expand);
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/TVM/TVMInstrInfo.td
+++ b/llvm/lib/Target/TVM/TVMInstrInfo.td
@@ -428,18 +428,31 @@ defm ISZERO : I<(outs I257:$dst), (ins I257:$src), (outs), (ins),
                  [(set I257:$dst, (setcc I257:$src, 0, SETEQ))],
                  "ISZERO\t$dst, $src", "ISZERO", 0xc000>;
 
-defm CONDSEL : I<(outs I257:$dst), (ins I257:$lhs, I257:$rhs, I257:$cond),
-                 (outs), (ins),
-                 [(set I257:$dst, (select I257:$cond, I257:$lhs, I257:$rhs))],
-                 "COND\t$dst, $lhs, $rhs, $cond", "CONDSEL", 0xe304>;
+multiclass CONDSEL_TEMPLATE<TVMRegClass RC> :
+  I<(outs RC:$dst), (ins I257:$cond, RC:$lhs, RC:$rhs), (outs), (ins),
+    [(set RC:$dst, (select I257:$cond, RC:$lhs, RC:$rhs))],
+    "COND\t$dst, $cond, $lhs, $rhs", "CONDSEL", 0xe304>;
+
+defm CONDSEL_I : CONDSEL_TEMPLATE<I257>;
+defm CONDSEL_T : CONDSEL_TEMPLATE<Tuple>;
+defm CONDSEL_S : CONDSEL_TEMPLATE<Slice>;
+defm CONDSEL_B : CONDSEL_TEMPLATE<Builder>;
+defm CONDSEL_C : CONDSEL_TEMPLATE<Cell>;
 
 // ISD::SELECT requires its operand to conform to getBooleanContents, but
 // TVM's CONDSEL interprets any non-zero value as true, so we can fold
 // a setne and seteq with 0 into a select.
-def : Pat<(select (i257 (seteq I257:$cond, 0)), I257:$lhs, I257:$rhs),
-          (CONDSEL I257:$lhs, I257:$rhs, I257:$cond)>;
-def : Pat<(select (i257 (setne I257:$cond, 0)), I257:$lhs, I257:$rhs),
-          (CONDSEL I257:$rhs, I257:$lhs, I257:$cond)>;
+multiclass CONDSEL_PATTERNS<ValueType VT, TVMRegClass RC, NI CS> {
+def : Pat<(select (i257 (seteq I257:$cond, (i257 0))), RC:$lhs, RC:$rhs),
+          (CS I257:$cond, RC:$rhs, RC:$lhs)>;
+def : Pat<(select (i257 (setne I257:$cond, (i257 0))), RC:$lhs, RC:$rhs),
+          (CS I257:$cond, RC:$lhs, RC:$rhs)>;
+}
+defm : CONDSEL_PATTERNS<i257, I257, CONDSEL_I>;
+defm : CONDSEL_PATTERNS<TVMTuple, Tuple, CONDSEL_T>;
+defm : CONDSEL_PATTERNS<TVMSlice, Slice, CONDSEL_S>;
+defm : CONDSEL_PATTERNS<TVMBuilder, Builder, CONDSEL_B>;
+defm : CONDSEL_PATTERNS<TVMCell, Cell, CONDSEL_C>;
 
 include "TVMTupleInstrInfo.td"
 include "TVMLiteralInstrInfo.td"

--- a/llvm/lib/Target/TVM/TVMStackPatterns.cpp
+++ b/llvm/lib/Target/TVM/TVMStackPatterns.cpp
@@ -356,9 +356,15 @@ void pattern3_ppx(StackFixup &Rv, unsigned i, unsigned j, unsigned k) {
   }
 
   // { axc|b } => { axc|ba } => { axc|ab } => error j+1=0,j=?
-  if (j == 0) {                  // { axc|b }
+  if (j == 0 && k != 1) {                  // { axc|b }
     pattern3_xpp(Rv, k, i, k);   // { axb|c } => { axb|ca } => { axb|cab }
     Rv(StackFixup::makeRoll(2)); // { axb|abc }
+    return;
+  }
+  // { ab|cx }
+  if (k == 1) {
+    pattern2_pp(Rv, i, j);       // { ab|cxab }
+    Rv(StackFixup::makeRoll(3)); // { ab|cxab }
     return;
   }
 

--- a/llvm/test/CodeGen/TVM/icmp.ll
+++ b/llvm/test/CodeGen/TVM/icmp.ll
@@ -14,10 +14,11 @@ define i257 @icmpeq(i257 %par1, i257 %par2) nounwind {
 }
 
 ; CHECK-LABEL: icmpeq0
+; (par == 0) ? 42 : 77  => (!par) ? 42 : 77 => par ? 77 : 42
 define i257 @icmpeq0(i257 %par1) nounwind {
 ; CHECK-NOT: EQUAL
-; CHECK: PUSHINT 42
-; CHECK-NEXT: PUSHINT 77
+; CHECK: PUSHINT 77
+; CHECK-NEXT: PUSHINT 42
 ; CHECK: CONDSEL
   %1 = icmp eq i257 %par1, 0
   %2 = select i1 %1, i257 42, i257 77
@@ -33,10 +34,11 @@ define i257 @icmpneq(i257 %par1, i257 %par2) nounwind {
 }
 
 ; CHECK-LABEL: icmpneq0
+; (par != 0) ? 42 : 77  => (par) ? 42 : 77
 define i257 @icmpneq0(i257 %par1) nounwind {
 ; CHECK-NOT: NEQ
-; CHECK: PUSHINT 77
-; CHECK-NEXT: PUSHINT 42
+; CHECK: PUSHINT 42
+; CHECK-NEXT: PUSHINT 77
 ; CHECK: CONDSEL
   %1 = icmp ne i257 %par1, 0
   %2 = select i1 %1, i257 42, i257 77

--- a/llvm/test/CodeGen/TVM/select-isel.ll
+++ b/llvm/test/CodeGen/TVM/select-isel.ll
@@ -9,9 +9,45 @@ entry:
 ; CHECK-NEXT: EQUAL
 ; CHECK-NEXT: PUSHINT 7
 ; CHECK-NEXT: PUSHINT 13
-; CHECK-NEXT: BLKSWAP 1, 2
 ; CHECK-NEXT: CONDSEL
   %cmp = icmp eq i257 %x, -115792089237316195423570985008687907853269984665640564039457584007913129639936
   %ret = select i1 %cmp, i257 7, i257 13
   ret i257 %ret
 }
+
+define tuple @select_tuple(i257 %x, tuple %a, tuple %b) {
+entry:
+; CHECK-LABEL: select_tuple
+; CHECK:       CONDSEL
+  %cmp = icmp ne i257 %x, 0
+  %ret = select i1 %cmp, tuple %a, tuple %b
+  ret tuple %ret
+}
+
+define slice @select_slice(i257 %x, slice %a, slice %b) {
+entry:
+; CHECK-LABEL: select_slice
+; CHECK:       CONDSEL
+  %cmp = icmp ne i257 %x, 0
+  %ret = select i1 %cmp, slice %a, slice %b
+  ret slice %ret
+}
+
+define builder @select_builder(i257 %x, builder %a, builder %b) {
+entry:
+; CHECK-LABEL: select_builder
+; CHECK:       CONDSEL
+  %cmp = icmp ne i257 %x, 0
+  %ret = select i1 %cmp, builder %a, builder %b
+  ret builder %ret
+}
+
+define cell @select_cell(i257 %x, cell %a, cell %b) {
+entry:
+; CHECK-LABEL: select_cell
+; CHECK:       CONDSEL
+  %cmp = icmp ne i257 %x, 0
+  %ret = select i1 %cmp, cell %a, cell %b
+  ret cell %ret
+}
+


### PR DESCRIPTION
Subpart of c++ suppport.
Also fixed ppx (push, push, exchange) stack pattern problem, revealed by toolchain-test-suite/llvm/clang/gcc.c-torture/compile/20120927-1.c test.