### PR TITLE
Fix for dead arg elimination for tvm types - from upstream

### DIFF
--- a/llvm/lib/Target/TVM/TVMStack.cpp
+++ b/llvm/lib/Target/TVM/TVMStack.cpp
@@ -118,6 +118,13 @@ void Stack::filterByDeadDefs(MachineInstr &MI) {
   }
 }
 
+void Stack::filterByImpDefs(const Stack &TheStack) {
+  for (auto &Vreg : Data) {
+    if (Vreg.VirtReg != TVMFunctionInfo::UnusedReg && !TheStack.exist(Vreg))
+      Vreg.VirtReg = TVMFunctionInfo::UnusedReg;
+  }
+}
+
 void Stack::fillUnusedRegs(SmallVector<StackVreg, 16> &Regs) {
   for (StackVreg &VR : Data) {
     if (Regs.empty())

--- a/llvm/lib/Target/TVM/TVMStack.h
+++ b/llvm/lib/Target/TVM/TVMStack.h
@@ -88,6 +88,9 @@ public:
 
   void filterByDeadDefs(MachineInstr &MI);
 
+  /// Replace regs, absent in TheStack, by UnusedReg (for undefs)
+  void filterByImpDefs(const Stack &TheStack);
+
   /// Occupy unused space in stack (filled with unused registers) with \par
   /// Regs.
   void fillUnusedRegs(SmallVector<StackVreg, 16> &Regs);

--- a/llvm/lib/Target/TVM/TVMStackModel.cpp
+++ b/llvm/lib/Target/TVM/TVMStackModel.cpp
@@ -576,6 +576,7 @@ StackFixup TVMStackModel::prepareStackFor(MachineInstr &MI,
     //  dst road pattern plus required arguments
     auto AfterTermStack = BBInfo[MBB].fixedEnd();
     auto NeedStack = AfterTermStack.withArgs(MIArgs(MI, *LIS, Index));
+    NeedStack.filterByImpDefs(TheStack);
     auto Fix = NeedStack - TheStack;
     if (DebugMessage)
       *DebugMessage = NeedStack.toString();
@@ -588,6 +589,8 @@ StackFixup TVMStackModel::prepareStackFor(MachineInstr &MI,
 
 void TVMStackModel::modelInstructionExecution(MachineInstr &MI,
                                               Stack &StackBefore) {
+  if (MI.isImplicitDef())
+    return;
   size_t NumDefs = MI.getNumDefs();
   size_t NumStackOperands = llvm::count_if(
       MI.uses(), [](const MachineOperand &MO) { return MO.isReg(); });

--- a/llvm/test/CodeGen/TVM/dead-arg-fix.ll
+++ b/llvm/test/CodeGen/TVM/dead-arg-fix.ll
@@ -1,0 +1,52 @@
+; RUN: opt -deadargelim -S < %s | FileCheck %s
+; REQUIRES: tvm-registered-target
+
+target datalayout = "E-S257-i1:257:257-i8:257:257-i16:257:257-i32:257:257-i64:257:257-i257:257:257-p:257:257-a:257:257"
+target triple = "tvm"
+
+define internal i257 @cond_func(i257 %a) local_unnamed_addr noinline {
+entry:
+  %cmp = icmp sgt i257 %a, 0
+  %conv = zext i1 %cmp to i257
+  ret i257 %conv
+}
+
+define internal i257 @bar(i257 %a, slice %sl, i257 %c) local_unnamed_addr noinline {
+entry:
+  %add = add nsw i257 %c, %a
+  ret i257 %add
+}
+
+define internal i257 @baz(i257 %a, i257 %b, slice %sl) local_unnamed_addr noinline {
+entry:
+  %sub = sub nsw i257 %a, %b
+  ret i257 %sub
+}
+
+define internal i257 @foo(i257 %a, slice %sl, i257 %c) local_unnamed_addr noinline {
+entry:
+  %call = tail call i257 @cond_func(i257 %a)
+  %tobool = icmp eq i257 %call, 0
+  br i1 %tobool, label %if.end, label %if.then
+
+if.then:                                          ; preds = %entry
+  %call1 = tail call i257 @bar(i257 %a, slice %sl, i257 %c)
+  br label %return
+
+if.end:                                           ; preds = %entry
+  %call2 = tail call i257 @baz(i257 %a, i257 %c, slice %sl)
+  br label %return
+
+return:                                           ; preds = %if.end, %if.then
+  %retval.0 = phi i257 [ %call1, %if.then ], [ %call2, %if.end ]
+  ret i257 %retval.0
+}
+
+; CHECK-LABEL: define i257 @test(i257 %a, slice %sl, i257 %b)
+define i257 @test(i257 %a, slice %sl, i257 %b) local_unnamed_addr #1 {
+entry:
+; CHECK: call i257 @foo(i257 %a, i257 %b)
+  %call = tail call i257 @foo(i257 %a, slice %sl, i257 %b)
+  ret i257 %call
+}
+

--- a/llvm/test/CodeGen/TVM/undef-cfg.ll
+++ b/llvm/test/CodeGen/TVM/undef-cfg.ll
@@ -1,0 +1,26 @@
+; RUN: llc < %s -march=tvm -asm-verbose=false | FileCheck %s
+
+target datalayout = "E-S257-i1:257:257-i8:257:257-i16:257:257-i32:257:257-i64:257:257-i257:257:257-p:257:257-a:257:257"
+target triple = "tvm"
+
+declare i257 @cfg_left(i257, i257, i257)
+declare i257 @cfg_right(i257, i257, i257)
+define { i257, i257 } @cfg_undefs(i257 %v0, i257 %v1, i257 %v2) {
+; CHECK-LABEL: cfg_undefs
+entry:
+  %cond = icmp ne i257 %v0, 0
+  br i1 %cond, label %true_bb, label %false_bb
+true_bb:
+  %true_call_v = call i257 @cfg_left(i257 %v0, i257 %v1, i257 %v2)
+  br label %tail
+false_bb:
+  %false_call_v = call i257 @cfg_right(i257 %v0, i257 %v1, i257 %v2)
+  br label %tail
+tail:
+  %ph0 = phi i257 [undef, %true_bb], [%false_call_v, %false_bb]
+  %ph1 = phi i257 [%true_call_v, %true_bb], [undef, %false_bb]
+  %ret0 = insertvalue { i257, i257 } undef, i257 %ph0, 0
+  %ret1 = insertvalue { i257, i257 } %ret0, i257 %ph1, 1
+  ret { i257, i257 } %ret1
+}
+

--- a/llvm/tools/clang/lib/AST/ExprConstant.cpp
+++ b/llvm/tools/clang/lib/AST/ExprConstant.cpp
@@ -8967,10 +8967,13 @@ EvaluateComparisonBinaryOperator(EvalInfo &Info, const BinaryOperator *E,
     unsigned PtrSize = Info.Ctx.getTypeSize(LHSTy);
     uint64_t CompareLHS = LHSOffset.getQuantity();
     uint64_t CompareRHS = RHSOffset.getQuantity();
-    assert(PtrSize <= 64 && "Unexpected pointer width");
-    uint64_t Mask = ~0ULL >> (64 - PtrSize);
-    CompareLHS &= Mask;
-    CompareRHS &= Mask;
+    // TVM local begin
+    if (PtrSize <= 64) {
+      uint64_t Mask = ~0ULL >> (64 - PtrSize);
+      CompareLHS &= Mask;
+      CompareRHS &= Mask;
+    }
+    // TVM local end
 
     // If there is a base and this is a relational operator, we can only
     // compare pointers within the object in question; otherwise, the result

--- a/llvm/tools/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/llvm/tools/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -1844,7 +1844,8 @@ CodeGenFunction::EmitNullInitialization(Address DestPtr, QualType Ty) {
   // Otherwise, just memset the whole thing to zero.  This is legal
   // because in LLVM, all default initializers (other than the ones we just
   // handled above) are guaranteed to have a bit pattern of all zeros.
-  // TVM local bgin: Byte instead of Int8
+
+  // TVM local begin
   Builder.CreateMemSet(DestPtr, Builder.getByte(0), SizeVal, false);
   // TVM local end
 }

--- a/llvm/tools/clang/lib/Lex/LiteralSupport.cpp
+++ b/llvm/tools/clang/lib/Lex/LiteralSupport.cpp
@@ -164,7 +164,9 @@ static unsigned ProcessCharEscape(const char *ThisTokBegin,
     }
 
     // See if any bits will be truncated when evaluated as a character.
-    if (CharWidth != 32 && (ResultChar >> CharWidth) != 0) {
+    // TVM local begin
+    if (CharWidth < 32 && ((ResultChar >> CharWidth) != 0)) {
+    // TVM local end
       Overflow = true;
       ResultChar &= ~0U >> (32-CharWidth);
     }

--- a/llvm/tools/clang/test/CodeGen/tvm/char-truncate.c
+++ b/llvm/tools/clang/test/CodeGen/tvm/char-truncate.c
@@ -1,0 +1,17 @@
+// RUN: %clang -O3 -S -c -emit-llvm -target tvm %s -o - | FileCheck %s
+// REQUIRES: tvm-registered-target
+
+static const char arr[] = { '\xFFFFFFFF', '\x10000000' };
+
+// CHECK-LABEL: @foo
+// CHECK: ret i257 4294967295
+char foo() {
+  return arr[0];
+}
+
+// CHECK-LABEL: @bar
+// CHECK: ret i257 268435456
+char bar() {
+  return arr[1];
+}
+

--- a/llvm/tools/clang/test/CodeGen/tvm/msg-address-intrinsics.cpp
+++ b/llvm/tools/clang/test/CodeGen/tvm/msg-address-intrinsics.cpp
@@ -1,7 +1,5 @@
-// RUN: %clang -O3 -S -c -I%S/../../../../../../stdlib/cpp-sdk/ -emit-llvm -target tvm %s -o - | FileCheck %s
+// RUN: %clang -O3 -S -c -emit-llvm -target tvm %s -o - | FileCheck %s
 // REQUIRES: tvm-registered-target
-
-#include "msg_address.hpp"
 
 int get_msg_kind(__tvm_slice sl) {
 // CHECK: get_msg_kind

--- a/llvm/tools/clang/test/CodeGen/tvm/ptr-cmp.c
+++ b/llvm/tools/clang/test/CodeGen/tvm/ptr-cmp.c
@@ -1,0 +1,17 @@
+// RUN: %clang -O3 -S -c -emit-llvm -target tvm %s -o - | FileCheck %s
+// REQUIRES: tvm-registered-target
+
+typedef struct str {
+  int x;
+  int y;
+} str_t;
+
+// CHECK-LABEL: @foo
+// CHECK: ret i257 1
+int foo() {
+  str_t v;
+  if (&v.y > &v.x)
+    return 1;
+  return -1;
+}
+


### PR DESCRIPTION
Dependent from #73
Dependent from #71

Subpart of c++ suppport.