### PR TITLE
Export & Import of Json ABI for c++

### DIFF
--- a/llvm/include/llvm/IR/IRPrintingPasses.h
+++ b/llvm/include/llvm/IR/IRPrintingPasses.h
@@ -49,6 +49,13 @@ FunctionPass *createPrintFunctionPass(raw_ostream &OS,
 BasicBlockPass *createPrintBasicBlockPass(raw_ostream &OS,
                                           const std::string &Banner = "");
 
+// TVM local begin
+/// Create and return a pass that writes the text global constant
+/// to the specified \c raw_ostream.
+ModulePass *createPrintTextConstantPass(raw_ostream &OS,
+                                        const std::string &ConstantName = "");
+// TVM local end
+
 /// Print out a name of an LLVM value without any prefixes.
 ///
 /// The name is surrounded with ""'s and escaped if it has any special or

--- a/llvm/include/llvm/InitializePasses.h
+++ b/llvm/include/llvm/InitializePasses.h
@@ -316,6 +316,9 @@ void initializePostRASchedulerPass(PassRegistry&);
 void initializePreISelIntrinsicLoweringLegacyPassPass(PassRegistry&);
 void initializePredicateInfoPrinterLegacyPassPass(PassRegistry&);
 void initializePrintBasicBlockPassPass(PassRegistry&);
+// TVM local begin
+void initializePrintTextConstantPassPass(PassRegistry&);
+// TVM local end
 void initializePrintFunctionPassWrapperPass(PassRegistry&);
 void initializePrintModulePassWrapperPass(PassRegistry&);
 void initializeProcessImplicitDefsPass(PassRegistry&);

--- a/llvm/include/llvm/LinkAllPasses.h
+++ b/llvm/include/llvm/LinkAllPasses.h
@@ -196,6 +196,9 @@ namespace {
       (void) llvm::createPrintModulePass(os);
       (void) llvm::createPrintFunctionPass(os);
       (void) llvm::createPrintBasicBlockPass(os);
+      // TVM local begin
+      (void) llvm::createPrintTextConstantPass(os);
+      // TVM local end
       (void) llvm::createModuleDebugInfoPrinterPass();
       (void) llvm::createPartialInliningPass();
       (void) llvm::createLintPass();

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -49,6 +49,9 @@ void llvm::initializeCore(PassRegistry &Registry) {
   initializePrintModulePassWrapperPass(Registry);
   initializePrintFunctionPassWrapperPass(Registry);
   initializePrintBasicBlockPassPass(Registry);
+  // TVM local begin
+  initializePrintTextConstantPassPass(Registry);
+  // TVM local end
   initializeSafepointIRVerifierPass(Registry);
   initializeVerifierLegacyPassPass(Registry);
 }

--- a/llvm/tools/clang/include/clang/AST/ASTContext.h
+++ b/llvm/tools/clang/include/clang/AST/ASTContext.h
@@ -256,6 +256,12 @@ class ASTContext : public RefCountedBase<ASTContext> {
   llvm::DenseMap<const MaterializeTemporaryExpr *, APValue *>
     MaterializedTemporaryValues;
 
+  // TVM local begin
+  /// A cache mapping from CXXMethodDecl to its TVM arguments structure.
+  mutable llvm::DenseMap<const CXXMethodDecl*, QualType>
+    TVMMethodArgStructs;
+  // TVM local end
+
   /// Representation of a "canonical" template template parameter that
   /// is used in canonical template names.
   class CanonicalTemplateTemplateParm : public llvm::FoldingSetNode {
@@ -326,6 +332,21 @@ class ASTContext : public RefCountedBase<ASTContext> {
 
   /// The identifier '__type_pack_element'.
   mutable IdentifierInfo *TypePackElementName = nullptr;
+
+  // TVM local begin
+  /// The identifier '__reflect_field'.
+  mutable IdentifierInfo *ReflectFieldName = nullptr;
+  /// The identifier '__reflect_methods_count'.
+  mutable IdentifierInfo *ReflectMethodsCountName = nullptr;
+  /// The identifier '__reflect_method_name'.
+  mutable IdentifierInfo *ReflectMethodNameName = nullptr;
+  /// The identifier '__reflect_method_func_id'.
+  mutable IdentifierInfo *ReflectMethodFuncIdName = nullptr;
+  /// The identifier '__reflect_method_rv'.
+  mutable IdentifierInfo *ReflectMethodRvName = nullptr;
+  /// The identifier '__reflect_method_arg_struct'.
+  mutable IdentifierInfo *ReflectMethodArgStructName = nullptr;
+  // TVM local end
 
   QualType ObjCConstantStringType;
   mutable RecordDecl *CFConstantStringTagDecl = nullptr;
@@ -506,6 +527,14 @@ private:
   mutable ExternCContextDecl *ExternCContext = nullptr;
   mutable BuiltinTemplateDecl *MakeIntegerSeqDecl = nullptr;
   mutable BuiltinTemplateDecl *TypePackElementDecl = nullptr;
+  // TVM local begin
+  mutable BuiltinTemplateDecl *ReflectFieldDecl = nullptr;
+  mutable BuiltinTemplateDecl *ReflectMethodsCountDecl = nullptr;
+  mutable BuiltinTemplateDecl *ReflectMethodNameDecl = nullptr;
+  mutable BuiltinTemplateDecl *ReflectMethodFuncIdDecl = nullptr;
+  mutable BuiltinTemplateDecl *ReflectMethodRvDecl = nullptr;
+  mutable BuiltinTemplateDecl *ReflectMethodArgStructDecl = nullptr;
+  // TVM local end
 
   /// The associated SourceManager object.
   SourceManager &SourceMgr;
@@ -1008,6 +1037,14 @@ public:
   ExternCContextDecl *getExternCContextDecl() const;
   BuiltinTemplateDecl *getMakeIntegerSeqDecl() const;
   BuiltinTemplateDecl *getTypePackElementDecl() const;
+  // TVM local begin
+  BuiltinTemplateDecl *getReflectFieldDecl() const;
+  BuiltinTemplateDecl *getReflectMethodsCountDecl() const;
+  BuiltinTemplateDecl *getReflectMethodNameDecl() const;
+  BuiltinTemplateDecl *getReflectMethodFuncIdDecl() const;
+  BuiltinTemplateDecl *getReflectMethodRvDecl() const;
+  BuiltinTemplateDecl *getReflectMethodArgStructDecl() const;
+  // TVM local end
 
   // Builtin Types.
   CanQualType VoidTy;
@@ -1368,6 +1405,10 @@ public:
   ///  (for builtin functions with struct returns)
   QualType prepareTVMLiteralStructType(ArrayRef<QualType> Elems,
                                        StringRef ElemsStr) const;
+
+  /// Creating struct with combined arguments for Method (without `this`)
+  QualType prepareTVMArgumentsStructType(CXXMethodDecl *Method) const;
+  QualType getTVMArgumentsStructType(CXXMethodDecl *Method) const;
   // TVM local end
 
   /// \pre Return a non-unique reference to the type for a dependently-sized
@@ -1750,6 +1791,44 @@ public:
       TypePackElementName = &Idents.get("__type_pack_element");
     return TypePackElementName;
   }
+
+  // TVM local begin
+  IdentifierInfo *getReflectFieldName() const {
+    if (!ReflectFieldName)
+      ReflectFieldName = &Idents.get("__reflect_field");
+    return ReflectFieldName;
+  }
+
+  IdentifierInfo *getReflectMethodsCountName() const {
+    if (!ReflectMethodsCountName)
+      ReflectMethodsCountName = &Idents.get("__reflect_methods_count");
+    return ReflectMethodsCountName;
+  }
+
+  IdentifierInfo *getReflectMethodNameName() const {
+    if (!ReflectMethodNameName)
+      ReflectMethodNameName = &Idents.get("__reflect_method_name");
+    return ReflectMethodNameName;
+  }
+
+  IdentifierInfo *getReflectMethodFuncIdName() const {
+    if (!ReflectMethodFuncIdName)
+      ReflectMethodFuncIdName = &Idents.get("__reflect_method_func_id");
+    return ReflectMethodFuncIdName;
+  }
+
+  IdentifierInfo *getReflectMethodRvName() const {
+    if (!ReflectMethodRvName)
+      ReflectMethodRvName = &Idents.get("__reflect_method_rv");
+    return ReflectMethodRvName;
+  }
+
+  IdentifierInfo *getReflectMethodArgStructName() const {
+    if (!ReflectMethodArgStructName)
+      ReflectMethodArgStructName = &Idents.get("__reflect_method_arg_struct");
+    return ReflectMethodArgStructName;
+  }
+  // TVM local end
 
   /// Retrieve the Objective-C "instancetype" type, if already known;
   /// otherwise, returns a NULL type;

--- a/llvm/tools/clang/include/clang/AST/Decl.h
+++ b/llvm/tools/clang/include/clang/AST/Decl.h
@@ -1793,6 +1793,10 @@ private:
   unsigned HasODRHash : 1;
   unsigned ODRHash;
 
+  // TVM local begin
+  unsigned TVMFuncId = 0;
+  // TVM local end
+
   /// End part of this FunctionDecl's source range.
   ///
   /// We could compute the full range in getSourceRange(). However, when we're
@@ -2516,6 +2520,11 @@ public:
   /// Returns cached ODRHash of the function.  This must have been previously
   /// computed and stored.
   unsigned getODRHash() const;
+
+  // TVM local begin
+  void setTVMFuncId(unsigned FuncId) { TVMFuncId = FuncId; }
+  unsigned getTVMFuncId() const { return TVMFuncId; }
+  // TVM local end
 
   // Implement isa/cast/dyncast/etc.
   static bool classof(const Decl *D) { return classofKind(D->getKind()); }

--- a/llvm/tools/clang/include/clang/Basic/Builtins.h
+++ b/llvm/tools/clang/include/clang/Basic/Builtins.h
@@ -245,7 +245,27 @@ enum BuiltinTemplateKind : int {
   BTK__make_integer_seq,
 
   /// This names the __type_pack_element BuiltinTemplateDecl.
-  BTK__type_pack_element
+  BTK__type_pack_element,
+
+  // TVM local begin
+  /// This names the __reflect_field BuiltinTemplateDecl.
+  BTK__reflect_field,
+
+  /// This names the __reflect_methods_count BuiltinTemplateDecl.
+  BTK__reflect_methods_count,
+
+  /// This names the __reflect_method_name BuiltinTemplateDecl.
+  BTK__reflect_method_name,
+
+  /// This names the __reflect_method_func_id BuiltinTemplateDecl.
+  BTK__reflect_method_func_id,
+
+  /// This names the __reflect_method_rv BuiltinTemplateDecl.
+  BTK__reflect_method_rv,
+
+  /// This names the __reflect_method_arg_struct BuiltinTemplateDecl.
+  BTK__reflect_method_arg_struct
+  // TVM local end
 };
 
 } // end namespace clang

--- a/llvm/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/llvm/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -2456,6 +2456,16 @@ def err_integer_sequence_integral_element_type : Error<
 def err_type_pack_element_out_of_bounds : Error<
   "a parameter pack may not be accessed at an out of bounds index">;
 
+// TVM local begin
+// __reflect_field
+def err_reflect_field_not_struct_arg : Error<
+  "field name requested from non-struct type">;
+def err_reflect_field_big_index : Error<
+  "Too big index for field name">;
+def err_reflect_method_not_struct_arg : Error<
+  "reflect method requested from non-struct type">;
+// TVM local end
+
 // Objective-C++
 def err_objc_decls_may_only_appear_in_global_scope : Error<
   "Objective-C declarations may only appear in global scope">;

--- a/llvm/tools/clang/include/clang/CodeGen/BackendUtil.h
+++ b/llvm/tools/clang/include/clang/CodeGen/BackendUtil.h
@@ -32,6 +32,9 @@ namespace clang {
     Backend_EmitAssembly,  ///< Emit native assembly files
     Backend_EmitBC,        ///< Emit LLVM bitcode files
     Backend_EmitLL,        ///< Emit human-readable LLVM assembly
+    // TVM local begin
+    Backend_EmitTextConst, ///< Emit text global constant only
+    // TVM local end
     Backend_EmitNothing,   ///< Don't emit anything (benchmarking mode)
     Backend_EmitMCNull,    ///< Run CodeGen, but don't emit anything
     Backend_EmitObj        ///< Emit native object files

--- a/llvm/tools/clang/include/clang/CodeGen/CodeGenAction.h
+++ b/llvm/tools/clang/include/clang/CodeGen/CodeGenAction.h
@@ -99,6 +99,14 @@ public:
   EmitLLVMAction(llvm::LLVMContext *_VMContext = nullptr);
 };
 
+// TVM local begin
+class EmitTextConstAction : public CodeGenAction {
+  virtual void anchor();
+public:
+  EmitTextConstAction(llvm::LLVMContext *_VMContext = nullptr);
+};
+// TVM local end
+
 class EmitLLVMOnlyAction : public CodeGenAction {
   virtual void anchor();
 public:

--- a/llvm/tools/clang/include/clang/Driver/Options.td
+++ b/llvm/tools/clang/include/clang/Driver/Options.td
@@ -624,6 +624,16 @@ def emit_ast : Flag<["-"], "emit-ast">,
   HelpText<"Emit Clang AST files for source inputs">;
 def emit_llvm : Flag<["-"], "emit-llvm">, Flags<[CC1Option]>, Group<Action_Group>,
   HelpText<"Use the LLVM representation for assembler and object files">;
+// TVM local begin
+def emit_text_const : Joined<["-"], "emit-text-const=">, Flags<[CC1Option]>, Group<Action_Group>,
+  HelpText<"Emit text global constant">;
+def export_json_abi : Flag<["-"], "export-json-abi">, Flags<[CC1Option]>, Group<Action_Group>,
+  HelpText<"Print json abi for TVM c++ contract">;
+def import_json_abi : Flag<["-"], "import-json-abi">, Flags<[CC1Option]>, Group<Action_Group>,
+  HelpText<"Import json abi for TVM contract">;
+def import_json_name : Joined<["-"], "import-json-name=">, Flags<[CC1Option]>,
+  HelpText<"Override name for imported interface structure (file name by default)">;
+// TVM local end
 def exported__symbols__list : Separate<["-"], "exported_symbols_list">;
 def e : JoinedOrSeparate<["-"], "e">, Group<Link_Group>;
 def fPIC : Flag<["-"], "fPIC">, Group<f_Group>;

--- a/llvm/tools/clang/include/clang/Driver/Types.def
+++ b/llvm/tools/clang/include/clang/Driver/Types.def
@@ -88,6 +88,10 @@ TYPE("lto-ir",                   LTO_IR,       INVALID,         "s",     "")
 TYPE("lto-bc",                   LTO_BC,       INVALID,         "o",     "")
 
 // Misc.
+// TVM local begin
+TYPE("text-const",               TextConst,    INVALID,         "txt",   "u")
+TYPE("json-abi",                 JsonABI,      CXXHeader,       "abi",   "up")
+// TVM local end
 TYPE("ast",                      AST,          INVALID,         "ast",   "u")
 TYPE("pcm",                      ModuleFile,   INVALID,         "pcm",   "u")
 TYPE("plist",                    Plist,        INVALID,         "plist", "")

--- a/llvm/tools/clang/include/clang/Frontend/CodeGenOptions.h
+++ b/llvm/tools/clang/include/clang/Frontend/CodeGenOptions.h
@@ -214,6 +214,11 @@ public:
   /// records.
   std::string OptRecordFile;
 
+  // TVM local begin
+  /// The name of the text global constant to print
+  std::string EmitTextConstant;
+  // TVM local end
+
   /// Regular expression to select optimizations for which we should enable
   /// optimization remarks. Transformation passes whose name matches this
   /// expression (and support this feature), will emit a diagnostic

--- a/llvm/tools/clang/include/clang/Frontend/FrontendOptions.h
+++ b/llvm/tools/clang/include/clang/Frontend/FrontendOptions.h
@@ -64,6 +64,14 @@ enum ActionKind {
   /// Emit a .ll file.
   EmitLLVM,
 
+  // TVM local begin
+  /// Emit text global constant.
+  EmitTextConst,
+
+  /// Import TVM Json Abi.
+  ImportJsonAbi,
+  // TVM local end
+
   /// Generate LLVM IR, but do not emit anything.
   EmitLLVMOnly,
 
@@ -165,6 +173,9 @@ public:
     CUDA,
     RenderScript,
     HIP,
+    // TVM local begin
+    JsonAbi
+    // TVM local end
     ///@}
   };
 
@@ -437,6 +448,11 @@ public:
 
   /// Filename to write statistics to.
   std::string StatsFile;
+
+  // TVM local begin
+  /// Name for imported interface structure
+  std::string TVMJsonAbiStructName;
+  // TVM local end
 
 public:
   FrontendOptions()

--- a/llvm/tools/clang/include/clang/Frontend/TVMImportJsonAbi.h
+++ b/llvm/tools/clang/include/clang/Frontend/TVMImportJsonAbi.h
@@ -1,0 +1,34 @@
+// TVM local begin
+
+//===-- TVMImportJsonAbi.h - TVM Json Abi import ----*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Defines FrontendAction for import TVM Json Abi
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TVM_IMPORT_JSON_ABI_H
+#define LLVM_CLANG_TVM_IMPORT_JSON_ABI_H
+
+#include "clang/Frontend/FrontendActions.h"
+
+namespace clang {
+
+class ImportJsonAbiAction : public PreprocessorFrontendAction {
+  virtual void anchor();
+public:
+  void ExecuteAction() override;
+};
+
+}  // end namespace clang
+
+#endif
+
+// TVM local end

--- a/llvm/tools/clang/lib/CodeGen/BackendUtil.cpp
+++ b/llvm/tools/clang/lib/CodeGen/BackendUtil.cpp
@@ -748,7 +748,10 @@ void EmitAssemblyHelper::EmitAssembly(BackendAction Action,
 
   bool UsesCodeGen = (Action != Backend_EmitNothing &&
                       Action != Backend_EmitBC &&
-                      Action != Backend_EmitLL);
+                      Action != Backend_EmitLL &&
+                      // TVM local begin
+                      Action != Backend_EmitTextConst);
+                      // TVM local end
   CreateTargetMachine(UsesCodeGen);
 
   if (UsesCodeGen && !TM)
@@ -805,6 +808,13 @@ void EmitAssemblyHelper::EmitAssembly(BackendAction Action,
     PerModulePasses.add(
         createPrintModulePass(*OS, "", CodeGenOpts.EmitLLVMUseLists));
     break;
+
+  // TVM local begin
+  case Backend_EmitTextConst:
+    PerModulePasses.add(
+        createPrintTextConstantPass(*OS, CodeGenOpts.EmitTextConstant));
+    break;
+  // TVM local end
 
   default:
     if (!CodeGenOpts.SplitDwarfFile.empty()) {
@@ -1005,6 +1015,9 @@ void EmitAssemblyHelper::EmitAssemblyWithNewPassManager(
   // Append any output we need to the pass manager.
   switch (Action) {
   case Backend_EmitNothing:
+    // TVM local begin
+  case Backend_EmitTextConst:
+    // TVM local end
     break;
 
   case Backend_EmitBC:

--- a/llvm/tools/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/llvm/tools/clang/lib/CodeGen/CodeGenAction.cpp
@@ -831,6 +831,10 @@ GetOutputStream(CompilerInstance &CI, StringRef InFile, BackendAction Action) {
     return CI.createDefaultOutputFile(false, InFile, "s");
   case Backend_EmitLL:
     return CI.createDefaultOutputFile(false, InFile, "ll");
+  // TVM local begin
+  case Backend_EmitTextConst:
+    return CI.createDefaultOutputFile(false, InFile, "txt");
+  // TVM local end
   case Backend_EmitBC:
     return CI.createDefaultOutputFile(true, InFile, "bc");
   case Backend_EmitNothing:
@@ -1057,6 +1061,12 @@ EmitBCAction::EmitBCAction(llvm::LLVMContext *_VMContext)
 void EmitLLVMAction::anchor() { }
 EmitLLVMAction::EmitLLVMAction(llvm::LLVMContext *_VMContext)
   : CodeGenAction(Backend_EmitLL, _VMContext) {}
+
+// TVM local begin
+void EmitTextConstAction::anchor() { }
+EmitTextConstAction::EmitTextConstAction(llvm::LLVMContext *_VMContext)
+  : CodeGenAction(Backend_EmitTextConst, _VMContext) {}
+// TVM local end
 
 void EmitLLVMOnlyAction::anchor() { }
 EmitLLVMOnlyAction::EmitLLVMOnlyAction(llvm::LLVMContext *_VMContext)

--- a/llvm/tools/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/llvm/tools/clang/lib/Driver/ToolChains/Clang.cpp
@@ -3252,6 +3252,14 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     } else if (JA.getType() == types::TY_LLVM_IR ||
                JA.getType() == types::TY_LTO_IR) {
       CmdArgs.push_back("-emit-llvm");
+    // TVM local begin
+    } else if (JA.getType() == types::TY_TextConst) {
+      const Arg *A = Args.getLastArg(options::OPT_emit_text_const);
+      if (A)
+        CmdArgs.push_back(Args.MakeArgString(A->getAsString(Args)));
+      else
+        CmdArgs.push_back("-emit-text-const=json_abi");
+    // TVM local end
     } else if (JA.getType() == types::TY_LLVM_BC ||
                JA.getType() == types::TY_LTO_BC) {
       CmdArgs.push_back("-emit-llvm-bc");

--- a/llvm/tools/clang/lib/Driver/ToolChains/TVM.cpp
+++ b/llvm/tools/clang/lib/Driver/ToolChains/TVM.cpp
@@ -106,6 +106,10 @@ void TVM::addClangTargetOptions(const ArgList &DriverArgs,
   if (DriverArgs.hasFlag(clang::driver::options::OPT_fuse_init_array,
                          options::OPT_fno_use_init_array, true))
     CC1Args.push_back("-fuse-init-array");
+  if (auto *Arg = DriverArgs.getLastArg(options::OPT_import_json_abi))
+    Arg->render(DriverArgs, CC1Args);
+  if (auto *Arg = DriverArgs.getLastArg(options::OPT_import_json_name))
+    Arg->render(DriverArgs, CC1Args);
 }
 
 ToolChain::RuntimeLibType TVM::GetDefaultRuntimeLibType() const {

--- a/llvm/tools/clang/lib/Driver/Types.cpp
+++ b/llvm/tools/clang/lib/Driver/Types.cpp
@@ -250,6 +250,9 @@ types::ID types::lookupTypeForExtension(llvm::StringRef Ext) {
            .Case("c++m", TY_CXXModule)
            .Case("cppm", TY_CXXModule)
            .Case("cxxm", TY_CXXModule)
+           // TVM local begin
+           .Case("abi", TY_JsonABI)
+           // TVM local end
            .Default(TY_INVALID);
 }
 

--- a/llvm/tools/clang/lib/Frontend/CMakeLists.txt
+++ b/llvm/tools/clang/lib/Frontend/CMakeLists.txt
@@ -47,6 +47,7 @@ add_clang_library(clangFrontend
   TextDiagnostic.cpp
   TextDiagnosticBuffer.cpp
   TextDiagnosticPrinter.cpp
+  TVMImportJsonAbi.cpp
   VerifyDiagnosticConsumer.cpp
 
   DEPENDS

--- a/llvm/tools/clang/lib/Frontend/FrontendActions.cpp
+++ b/llvm/tools/clang/lib/Frontend/FrontendActions.cpp
@@ -779,6 +779,9 @@ void PrintPreambleAction::ExecuteAction() {
   case InputKind::Asm:
   case InputKind::LLVM_IR:
   case InputKind::RenderScript:
+  // TVM local begin
+  case InputKind::JsonAbi:
+  // TVM local end
     // We can't do anything with these.
     return;
   }

--- a/llvm/tools/clang/lib/Frontend/FrontendOptions.cpp
+++ b/llvm/tools/clang/lib/Frontend/FrontendOptions.cpp
@@ -31,5 +31,8 @@ InputKind FrontendOptions::getInputKindForExtension(StringRef Extension) {
     .Case("cl", InputKind::OpenCL)
     .Case("cu", InputKind::CUDA)
     .Cases("ll", "bc", InputKind::LLVM_IR)
+    // TVM local begin
+    .Case("abi", InputKind::JsonAbi)
+    // TVM local end
     .Default(InputKind::Unknown);
 }

--- a/llvm/tools/clang/lib/Frontend/TVMImportJsonAbi.cpp
+++ b/llvm/tools/clang/lib/Frontend/TVMImportJsonAbi.cpp
@@ -1,0 +1,132 @@
+// TVM local begin
+
+#include "clang/Frontend/TVMImportJsonAbi.h"
+
+#include "clang/Frontend/CompilerInstance.h"
+#include "llvm/Support/JSON.h"
+#include "llvm/Support/Path.h"
+
+using namespace clang;
+
+void ImportJsonAbiAction::anchor() { }
+
+namespace {
+llvm::Optional<std::string> CppTypeForJsonAbiType(StringRef JsonAbiName) {
+  if (JsonAbiName == "address")
+    return std::string("MsgAddress");
+  if (JsonAbiName == "bool")
+    return std::string("bool_t");
+  if (JsonAbiName.consume_front("uint")) {
+    unsigned BitSize;
+    if (!JsonAbiName.getAsInteger(10, BitSize))
+      return std::string("uint_t<" + std::to_string(BitSize) + ">");
+    return {};
+  }
+  if (JsonAbiName.consume_front("int")) {
+    unsigned BitSize;
+    if (!JsonAbiName.getAsInteger(10, BitSize))
+      return std::string("int_t<" + std::to_string(BitSize) + ">");
+    return {};
+  }
+  return {};
+}
+}
+
+void ImportJsonAbiAction::ExecuteAction() {
+#ifdef JSON_ABI_LOCAL_ASSERT
+#error "JSON_ABI_LOCAL_ASSERT macros override"
+#endif
+#define JSON_ABI_LOCAL_ASSERT(Cond, Err) \
+  if (!(Cond)) { \
+    unsigned DiagID = \
+        CI.getDiagnostics().getCustomDiagID(DiagnosticsEngine::Error, "%0"); \
+    CI.getDiagnostics().Report(DiagID) << Err; \
+    return; \
+  }
+
+  CompilerInstance &CI = getCompilerInstance();
+  auto Buffer = CI.getFileManager().getBufferForFile(getCurrentFile());
+  if (!Buffer) {
+      CI.getDiagnostics().Report(diag::err_cannot_open_file)
+          << getCurrentFile() << Buffer.getError().message();
+      return;
+  }
+  std::unique_ptr<raw_pwrite_stream> OS =
+      CI.createDefaultOutputFile(true, getCurrentFile(), "hpp");
+  if (!OS)
+    return;
+  if (auto E = llvm::json::parse(Buffer.get()->getBuffer())) {
+    const auto *Abi = E->getAsObject();
+    JSON_ABI_LOCAL_ASSERT(Abi, "Wrong abi")
+    auto AbiVer = Abi->getInteger("ABI version");
+    JSON_ABI_LOCAL_ASSERT(AbiVer && *AbiVer == 1, "Wrong abi version")
+
+    *OS << "#pragma once\n\n";
+    *OS << "#include <tvm/schema/message.hpp>\n\n";
+    *OS << "namespace tvm { namespace schema {\n\n";
+
+    auto InterfaceName = CI.getFrontendOpts().TVMJsonAbiStructName;
+    if (InterfaceName.empty()) {
+      StringRef fname = llvm::sys::path::filename(getCurrentFile());
+      size_t pos = fname.find_first_of('.');
+      if (pos != StringRef::npos)
+        fname = fname.substr(0, pos);
+      InterfaceName = ("I" + fname).str();
+    }
+
+    *OS << "struct " << InterfaceName << " {\n";
+
+    const auto *Functions = Abi->getArray("functions");
+    for (const auto &Func : *Functions) {
+      auto *FunObj = Func.getAsObject();
+      JSON_ABI_LOCAL_ASSERT(FunObj && FunObj->getString("name"),
+                            "Wrong function")
+      const auto *Outputs = FunObj->getArray("outputs");
+      *OS << "  ";
+      if (Outputs->size() == 1) {
+        auto *OutputObj = Outputs->front().getAsObject();
+        JSON_ABI_LOCAL_ASSERT(OutputObj, "Wrong output")
+        auto RvType = OutputObj->getString("type");
+        auto CppType = CppTypeForJsonAbiType(*RvType);
+        *OS << *CppType;
+      } else {
+        *OS << "void";
+      }
+
+      *OS << " " << *FunObj->getString("name") << "(";
+      const auto *Inputs = FunObj->getArray("inputs");
+      if (Inputs) {
+        bool IsFirst = true;
+        for (const auto &Input : *Inputs) {
+          if (auto *InputObj = Input.getAsObject()) {
+            auto ParamName = InputObj->getString("name");
+            auto ParamType = InputObj->getString("type");
+            JSON_ABI_LOCAL_ASSERT(ParamName && ParamType,
+                                  "Wrong function input")
+            auto CppType = CppTypeForJsonAbiType(*ParamType);
+            JSON_ABI_LOCAL_ASSERT(CppType, "Unsupported input type")
+            if (!IsFirst) *OS << ", ";
+            IsFirst = false;
+            *OS << *CppType << " " << *ParamName;
+          }
+        }
+      }
+      *OS << ")";
+      auto FuncId = FunObj->getInteger("id");
+      if (FuncId)
+        *OS << " = " << *FuncId;
+      *OS << ";\n";
+    }
+
+    *OS << "};\n\n";
+    *OS << "}} // namespace tvm::schema\n";
+  } else {
+    handleAllErrors(E.takeError(), [&](const llvm::ErrorInfoBase &E) {
+      unsigned DiagID =
+          CI.getDiagnostics().getCustomDiagID(DiagnosticsEngine::Error, "%0");
+      CI.getDiagnostics().Report(DiagID) << E.message();
+    });
+  }
+  #undef JSON_ABI_LOCAL_ASSERT
+}
+// TVM local end

--- a/llvm/tools/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
+++ b/llvm/tools/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
@@ -22,6 +22,7 @@
 #include "clang/Frontend/FrontendActions.h"
 #include "clang/Frontend/FrontendDiagnostic.h"
 #include "clang/Frontend/FrontendPluginRegistry.h"
+#include "clang/Frontend/TVMImportJsonAbi.h"
 #include "clang/Frontend/Utils.h"
 #include "clang/Rewrite/Frontend/FrontendActions.h"
 #include "clang/StaticAnalyzer/Frontend/FrontendActions.h"
@@ -53,6 +54,10 @@ CreateFrontendBaseAction(CompilerInstance &CI) {
   case EmitBC:                 return llvm::make_unique<EmitBCAction>();
   case EmitHTML:               return llvm::make_unique<HTMLPrintAction>();
   case EmitLLVM:               return llvm::make_unique<EmitLLVMAction>();
+  // TVM local begin
+  case EmitTextConst:          return llvm::make_unique<EmitTextConstAction>();
+  case ImportJsonAbi:          return llvm::make_unique<ImportJsonAbiAction>();
+  // TVM local end
   case EmitLLVMOnly:           return llvm::make_unique<EmitLLVMOnlyAction>();
   case EmitCodeGenOnly:        return llvm::make_unique<EmitCodeGenOnlyAction>();
   case EmitObj:                return llvm::make_unique<EmitObjAction>();

--- a/llvm/tools/clang/lib/Lex/LiteralSupport.cpp
+++ b/llvm/tools/clang/lib/Lex/LiteralSupport.cpp
@@ -194,7 +194,9 @@ static unsigned ProcessCharEscape(const char *ThisTokBegin,
              ThisTokBuf[0] >= '0' && ThisTokBuf[0] <= '7');
 
     // Check for overflow.  Reject '\777', but not L'\777'.
-    if (CharWidth != 32 && (ResultChar >> CharWidth) != 0) {
+    // TVM local begin
+    if (CharWidth < 32 && (ResultChar >> CharWidth) != 0) {
+    // TVM local end
       if (Diags)
         Diag(Diags, Features, Loc, ThisTokBegin, EscapeBegin, ThisTokBuf,
              diag::err_escape_too_large) << 1;

--- a/llvm/tools/clang/lib/Lex/PPMacroExpansion.cpp
+++ b/llvm/tools/clang/lib/Lex/PPMacroExpansion.cpp
@@ -1623,6 +1623,7 @@ void Preprocessor::ExpandBuiltinMacro(Token &Tok) {
           return llvm::StringSwitch<bool>(II->getName())
                       .Case("__make_integer_seq", LangOpts.CPlusPlus)
                       .Case("__type_pack_element", LangOpts.CPlusPlus)
+                      .Case("__reflect_field", LangOpts.CPlusPlus)
                       .Case("__builtin_available", true)
                       .Case("__is_target_arch", true)
                       .Case("__is_target_vendor", true)

--- a/llvm/tools/clang/lib/Sema/SemaDecl.cpp
+++ b/llvm/tools/clang/lib/Sema/SemaDecl.cpp
@@ -10942,6 +10942,14 @@ void Sema::AddInitializerToDecl(Decl *RealDecl, Expr *Init, bool DirectInit) {
   }
 
   if (CXXMethodDecl *Method = dyn_cast<CXXMethodDecl>(RealDecl)) {
+    // TVM local begin
+    llvm::APSInt FuncId;
+    if (Context.getTargetInfo().getTriple().getArch() == llvm::Triple::tvm &&
+        Init->isIntegerConstantExpr(FuncId, Context)) {
+      Method->setTVMFuncId(static_cast<unsigned>(FuncId.getZExtValue()));
+      return;
+    }
+    // TVM local end
     // Pure-specifiers are handled in ActOnPureSpecifier.
     Diag(Method->getLocation(), diag::err_member_function_initialization)
       << Method->getDeclName() << Init->getSourceRange();

--- a/llvm/tools/clang/lib/Sema/SemaLookup.cpp
+++ b/llvm/tools/clang/lib/Sema/SemaLookup.cpp
@@ -688,7 +688,27 @@ static bool LookupBuiltin(Sema &S, LookupResult &R) {
         } else if (II == S.getASTContext().getTypePackElementName()) {
           R.addDecl(S.getASTContext().getTypePackElementDecl());
           return true;
+        // TVM local begin
+        } else if (II == S.getASTContext().getReflectFieldName()) {
+          R.addDecl(S.getASTContext().getReflectFieldDecl());
+          return true;
+        } else if (II == S.getASTContext().getReflectMethodsCountName()) {
+          R.addDecl(S.getASTContext().getReflectMethodsCountDecl());
+          return true;
+        } else if (II == S.getASTContext().getReflectMethodNameName()) {
+          R.addDecl(S.getASTContext().getReflectMethodNameDecl());
+          return true;
+        } else if (II == S.getASTContext().getReflectMethodFuncIdName()) {
+          R.addDecl(S.getASTContext().getReflectMethodFuncIdDecl());
+          return true;
+        } else if (II == S.getASTContext().getReflectMethodRvName()) {
+          R.addDecl(S.getASTContext().getReflectMethodRvDecl());
+          return true;
+        } else if (II == S.getASTContext().getReflectMethodArgStructName()) {
+          R.addDecl(S.getASTContext().getReflectMethodArgStructDecl());
+          return true;
         }
+        // TVM local end
       }
 
       // If this is a builtin on this (or all) targets, create the decl.

--- a/llvm/tools/clang/test/CodeGen/tvm/export-cpp-json.cpp
+++ b/llvm/tools/clang/test/CodeGen/tvm/export-cpp-json.cpp
@@ -1,0 +1,24 @@
+// RUN: %clang -target tvm -export-json-abi %s --sysroot=%S/../../../../../../stdlib -o - | FileCheck %s
+// REQUIRES: tvm-registered-target
+
+// CHECK: "functions":
+// CHECK: "name": "init"
+// CHECK: "name": "set_subscription_account"
+// CHECK: "name": "get_subscription_account"
+// CHECK: "name": "send_transaction"
+
+#include <tvm/schema/json-abi-gen.hpp>
+
+namespace tvm { namespace schema {
+
+struct IWallet {
+  void init() = 1;
+  void set_subscription_account(MsgAddress addr) = 2;
+  MsgAddress get_subscription_account() = 3;
+  void send_transaction(MsgAddress dest, uint_t<128> value, bool_t bounce) = 4;
+};
+
+}} // namespace tvm::schema
+
+DEFINE_JSON_ABI(tvm::schema::IWallet);
+

--- a/llvm/tools/clang/test/CodeGen/tvm/import-cpp-json.abi
+++ b/llvm/tools/clang/test/CodeGen/tvm/import-cpp-json.abi
@@ -1,0 +1,54 @@
+// RUN: tail -n +11 %s > %t1
+// RUN: %clang -target tvm -import-json-abi -import-json-name=IWallet %t1 -o - | FileCheck %s
+// REQUIRES: tvm-registered-target
+
+// CHECK: struct IWallet {
+// CHECK: void init() = 1;
+// CHECK: void set_subscription_account(MsgAddress addr) = 2;
+// CHECK: MsgAddress get_subscription_account() = 3;
+// CHECK: void send_transaction(MsgAddress dest, uint_t<128> value, bool_t bounce) = 4;
+// CHECK: }
+
+{
+  "ABI version": 1,
+  "functions": [
+  {
+    "name": "init",
+    "inputs": [
+    ],
+    "outputs": [
+    ],
+    "id": 1
+  },
+  {
+    "name": "set_subscription_account",
+    "inputs": [
+      { "name":"addr", "type":"address" }
+    ],
+    "outputs": [
+    ],
+    "id": 2
+  },
+  {
+    "name": "get_subscription_account",
+    "inputs": [
+    ],
+    "outputs": [
+      { "name":"value", "type":"address" }
+    ],
+    "id": 3
+  },
+  {
+    "name": "send_transaction",
+    "inputs": [
+      { "name":"dest", "type":"address" },
+      { "name":"value", "type":"uint128" },
+      { "name":"bounce", "type":"bool" }
+    ],
+    "outputs": [
+    ],
+    "id": 4
+  }
+  ]
+}
+

--- a/stdlib/cpp-sdk/tvm/schema/json-abi-gen.hpp
+++ b/stdlib/cpp-sdk/tvm/schema/json-abi-gen.hpp
@@ -1,0 +1,249 @@
+#pragma once
+
+#define BOOST_HANA_CONFIG_ENABLE_STRING_UDL
+
+#include <boost/hana/string.hpp>
+#include <boost/hana/power.hpp>
+#include <boost/hana/value.hpp>
+#include <boost/hana/div.hpp>
+#include <boost/hana/plus.hpp>
+#include <tvm/to_std_tuple.hpp>
+#include <tvm/schema/basics.hpp>
+#include <tvm/schema/message.hpp>
+
+/*
+{
+    "ABI version" : 0,
+    "functions" : [
+      {
+        "name" : "fn1",
+        "signed" : "false",
+        "inputs" : [
+          {"name" : "arg1", "type" : "uint64"}
+        ],
+        "outputs" : [
+          {"name" : "result", "type" : "uint64"}
+        ]
+      }
+    ]
+}
+*/
+
+namespace tvm { namespace schema { namespace json_abi_gen {
+
+namespace hana = boost::hana;
+using namespace hana::literals;
+
+constexpr size_t get_magnitude(size_t num) {
+  unsigned i = 0;
+  while (num > 0) {
+    num /= 10;
+    ++i;
+  }
+  return i;
+}
+
+template <class X, size_t ...i>
+constexpr auto to_string(X x, std::index_sequence<i...>) {
+  constexpr size_t mag = get_magnitude(X::value);
+  return hana::string<
+    (x / hana::power(hana::size_c<10>,
+                     hana::size_c<mag - i - 1>) % hana::size_c<10>
+                       + hana::size_c<48>)...>{};
+}
+
+template <class X>
+constexpr auto to_string(X) {
+  if constexpr (X::value == 0)
+    return "0"_s;
+  else
+    return to_string(hana::size_c<static_cast<size_t>(X::value)>,
+                     std::make_index_sequence<get_magnitude(X::value)>());
+}
+
+template<class T>
+struct make_simple_type_impl {
+  static constexpr auto value = "unknown"_s;
+};
+template<unsigned _bitlen>
+struct make_simple_type_impl<int_t<_bitlen>> {
+  static constexpr auto value = "int"_s + to_string(hana::integral_c<unsigned, _bitlen>);
+};
+template<unsigned _bitlen>
+struct make_simple_type_impl<uint_t<_bitlen>> {
+  static constexpr auto value = "uint"_s + to_string(hana::integral_c<unsigned, _bitlen>);
+};
+template<>
+struct make_simple_type_impl<uint_t<1>> {
+  static constexpr auto value = "bool"_s;
+};
+template<>
+struct make_simple_type_impl<MsgAddress> {
+  static constexpr auto value = "address"_s;
+};
+template<class T>
+constexpr auto make_simple_type() {
+  return make_simple_type_impl<T>::value;
+}
+
+template<class T>
+constexpr auto make_function_header(T func_name) {
+  return "\"name\": \""_s + func_name + "\""_s;
+}
+
+template<class ParentT, size_t FieldIndex>
+constexpr auto make_field_name() {
+  return __reflect_field<hana::string, ParentT, FieldIndex>{};
+};
+
+template<bool IsLast>
+constexpr auto make_field_impl_tail() {
+  if constexpr (IsLast)
+    return "}\n"_s;
+  else
+    return "},\n"_s;
+}
+
+template<class T, bool IsLast, class FieldName>
+constexpr auto make_field_impl(FieldName field_name) {
+  return "      { \"name\":\""_s + field_name + "\", \"type\":\""_s +
+      make_simple_type<T>() + "\" "_s + make_field_impl_tail<IsLast>();
+};
+
+template<class ParentT, size_t Size, size_t FieldIndex, class T>
+constexpr auto make_field_json() {
+  constexpr auto field_name = make_field_name<ParentT, FieldIndex>();
+  return make_field_impl<T, FieldIndex + 1 == Size>(field_name);
+};
+
+template<class ParentT, size_t Size, size_t FieldIndex, class T, class... Types>
+struct make_tuple_json_impl {
+  static constexpr auto value = make_field_json<ParentT, Size, FieldIndex, T>() +
+      make_tuple_json_impl<ParentT, Size, FieldIndex + 1, Types...>::value;
+};
+template<class ParentT, size_t Size, size_t FieldIndex, class T>
+struct make_tuple_json_impl<ParentT, Size, FieldIndex, T> {
+  static constexpr auto value = make_field_json<ParentT, Size, FieldIndex, T>();
+};
+template<class ParentT, class Tuple>
+struct make_tuple_json {};
+template<class ParentT, class... Types>
+struct make_tuple_json<ParentT, std::tuple<Types...>> {
+  static constexpr auto value = make_tuple_json_impl<ParentT, sizeof...(Types), 0, Types...>::value;
+};
+template<class ParentT>
+struct make_tuple_json<ParentT, std::tuple<>> {
+  static constexpr auto value = ""_s;
+};
+
+template<class T>
+struct make_struct_json {
+  static constexpr auto value = make_tuple_json<T, tvm::to_std_tuple_t<T>>::value;
+};
+template<>
+struct make_struct_json<void> {
+  static constexpr auto value = ""_s;
+};
+
+// For simple-type return value ("MsgAddress func()") we don't have name for field, so just "value"
+template<unsigned _bitlen>
+struct make_struct_json<int_t<_bitlen>> {
+  static constexpr auto value = make_field_impl<int_t<_bitlen>, 1>("value"_s);
+};
+template<unsigned _bitlen>
+struct make_struct_json<uint_t<_bitlen>> {
+  static constexpr auto value = make_field_impl<uint_t<_bitlen>, 1>("value"_s);
+};
+template<>
+struct make_struct_json<MsgAddress> {
+  static constexpr auto value = make_field_impl<MsgAddress, 1>("value"_s);
+};
+
+constexpr auto make_abi_version() {
+  return "\"ABI version\": 1"_s;
+}
+
+constexpr auto make_functions_begin() {
+  return "\"functions\": ["_s;
+}
+constexpr auto make_functions_end() {
+  return "\n  ]"_s;
+}
+
+template<class ArgStruct>
+constexpr auto make_function_inputs() {
+  return "\"inputs\": [\n"_s + make_struct_json<ArgStruct>::value + "    ]"_s;
+}
+
+template<class RvStruct>
+constexpr auto make_function_outputs() {
+  return "\"outputs\": [\n"_s + make_struct_json<RvStruct>::value + "    ]"_s;
+}
+
+
+template<unsigned FuncID>
+constexpr auto make_function_id() {
+  if constexpr (FuncID != 0)
+    return ",\n    \"id\": "_s + to_string(hana::integral_c<unsigned, FuncID>);
+  else
+    return ""_s;
+}
+
+template<unsigned FuncID, class RvStruct, class ArgStruct, class FuncName>
+constexpr auto make_function_json(FuncName func_name) {
+  constexpr auto hdr = make_function_header(func_name);
+  constexpr auto inputs = make_function_inputs<ArgStruct>();
+  constexpr auto outputs = make_function_outputs<RvStruct>();
+  constexpr auto id = make_function_id<FuncID>();
+  return "  {\n    "_s + hdr + ",\n    "_s + inputs + ",\n    "_s + outputs + id + "\n  }"_s;
+}
+
+template<class Interface>
+using get_interface_methods_count =
+  __reflect_methods_count<std::integral_constant, unsigned, Interface>;
+template<class Interface, unsigned Index>
+using get_interface_method_name = __reflect_method_name<hana::string, Interface, Index>;
+template<class Interface, unsigned Index>
+using get_interface_method_func_id =
+  __reflect_method_func_id<std::integral_constant, unsigned, Interface, Index>;
+template<class Interface, unsigned Index>
+using get_interface_method_rv = __reflect_method_rv<Interface, Index>;
+template<class Interface, unsigned Index>
+using get_interface_method_arg_struct = __reflect_method_arg_struct<Interface, Index>;
+
+template<class Interface, unsigned CurMethod, unsigned RestMethods>
+struct make_json_abi_impl {
+  static const unsigned FuncId = get_interface_method_func_id<Interface, CurMethod>::value;
+  using Rv = get_interface_method_rv<Interface, CurMethod>;
+  using Arg = get_interface_method_arg_struct<Interface, CurMethod>;
+  using FuncName = get_interface_method_name<Interface, CurMethod>;
+
+  static constexpr auto value = make_function_json<FuncId, Rv, Arg>(FuncName{}) + ",\n"_s +
+    make_json_abi_impl<Interface, CurMethod + 1, RestMethods - 1>::value;
+};
+template<class Interface, unsigned CurMethod>
+struct make_json_abi_impl<Interface, CurMethod, 1> {
+  static const unsigned FuncId = get_interface_method_func_id<Interface, CurMethod>::value;
+  using Rv = get_interface_method_rv<Interface, CurMethod>;
+  using Arg = get_interface_method_arg_struct<Interface, CurMethod>;
+  using FuncName = get_interface_method_name<Interface, CurMethod>;
+
+  static constexpr auto value = make_function_json<FuncId, Rv, Arg>(FuncName{});
+};
+template<class Interface, unsigned CurMethod>
+struct make_json_abi_impl<Interface, CurMethod, 0> {
+  static constexpr auto value = ""_s;
+};
+
+template<class Interface>
+constexpr auto make_json_abi() {
+  using MethodsCount = get_interface_methods_count<Interface>;
+  return "{\n  "_s + make_abi_version() + ",\n  "_s + make_functions_begin() + "\n"_s +
+      make_json_abi_impl<Interface, 0, MethodsCount::value>::value +
+      make_functions_end() + "\n}\n"_s;
+}
+
+#define DEFINE_JSON_ABI(Interface) \
+  const char* json_abi = tvm::schema::json_abi_gen::make_json_abi<Interface>().c_str()
+
+}}} // namespace tvm::schema::json_abi_gen

--- a/stdlib/cpp-sdk/tvm/to_std_tuple.hpp
+++ b/stdlib/cpp-sdk/tvm/to_std_tuple.hpp
@@ -1,10 +1,18 @@
 #pragma once
 
+#include <tuple>
+
 namespace tvm {
 
 template<size_t N>
 struct to_std_tuple_impl {
   static_assert("Unsupported to_std_tuple size");
+};
+
+template<> struct to_std_tuple_impl<0> {
+  template<typename _Tp> auto operator()(_Tp&&) const {
+    return std::tuple();
+  }
 };
 
 #ifdef TO_STD_TUPLE_CASE


### PR DESCRIPTION
Boost/hana in separate PR: https://github.com/tonlabs/TON-Compiler/pull/84

For export:
```
clang -target tvm -export-json-abi contract.cpp --sysroot=stdlib -o contract-json.abi
```
Will generate json-abi file for contract interface.
Interface should be defined in cpp file like:
```
struct IWallet {
  void init() = 1;
  void set_subscription_account(MsgAddress addr) = 2;
  MsgAddress get_subscription_account() = 3;
  void send_transaction(MsgAddress dest, uint_t<128> value, bool_t bounce) = 4;
};
DEFINE_JSON_ABI(IWallet);
```

For import:
```
clang -target tvm -import-json-abi -import-json-name=IContract contract-json.abi -o contract.inc.hpp
```
Will generate cpp header file with contract interface structure from json abi file.
