### PR TITLE
Fix internal outgoing message serialization

### DIFF
--- a/stdlib/ton-sdk/messages.inc
+++ b/stdlib/ton-sdk/messages.inc
@@ -31,7 +31,6 @@
     FIELD_UNSIGNED(address, 256)
 #include HEADER_OR_C
 
-
 #define TON_STRUCT_NAME MsgAddressExt
 #define TON_STRUCT \
     FIELD_UNSIGNED(zero_zero, 2)
@@ -41,16 +40,15 @@
 #define TON_STRUCT \
     FIELD_UNSIGNED(zero, 1) \
     FIELD_UNSIGNED(ihr_disabled, 1) \
-    FIELD_UNSIGNED(bounce, 1) \
-    FIELD_UNSIGNED(bounced, 1) \
+    FIELD_SIGNED(bounce, 1) \
+    FIELD_SIGNED(bounced, 1) \
     FIELD_COMPLEX(src, MsgAddressInt) \
     FIELD_COMPLEX(dst, MsgAddressInt) \
     FIELD_COMPLEX(value, CurrencyCollection) \
     FIELD_COMPLEX(ihr_fee, Grams) \
     FIELD_COMPLEX(fwd_fee, Grams) \
     FIELD_UNSIGNED(created_lt, 64) \
-    FIELD_UNSIGNED(created_at, 32) \
-    FIELD_UNSIGNED(amount, 16)
+    FIELD_UNSIGNED(created_at, 32)
 #include HEADER_OR_C
 
 #define TON_STRUCT_NAME CommonMsgInfo_ExtOut
@@ -65,7 +63,8 @@
 #define TON_STRUCT_NAME EmptyMessage
 #define TON_STRUCT \
     FIELD_COMPLEX(info, CommonMsgInfo) \
-    FIELD_UNSIGNED(init, 1)
+    FIELD_UNSIGNED(init, 1) \
+    FIELD_UNSIGNED(body, 1)
 #include HEADER_OR_C
 
 #define TON_STRUCT_NAME Message_ExtOut_int256


### PR DESCRIPTION
Remove amount field from CommonMsgInfo
Fix src address serialization, according to https://github.com/ton-blockchain/ton/blob/master/crypto/block/transaction.cpp#L1440
it must be either addr_none (0b00) or the sender contract's address.