### PR TITLE
Accept ABI file in abi_parser

### DIFF
--- a/stdlib/abi_parser.py
+++ b/stdlib/abi_parser.py
@@ -26,6 +26,8 @@ def convert_type (abi_type):
     errors.append ("Type %s is not supported yet\n" % abi_type)
     return ("int", ("Signed", 256))
 
+if (contract_name.endswith(".abi")):
+    contract_name = contract_name[:-4]
 contract_json = open("%s.abi" % contract_name)
 data = json.loads("".join ([x for x in contract_json]))
 contract_json.close()


### PR DESCRIPTION
The patch allows abi file name to be specified instead of the contract
name when generating C code with abi_parser.py tool.