### PR TITLE
Remove ACCEPT macro from TON SDK for C

### DIFF
--- a/stdlib/ton-sdk/tvm.h
+++ b/stdlib/ton-sdk/tvm.h
@@ -7,7 +7,6 @@
 #define XJOIN3(a,b,c) JOIN3(a,b,c)
 
 #define TVM_CUSTOM_EXCEPTION(id,val) enum { id = val };
-#define ACCEPT() __builtin_tvm_accept()
 
 typedef __tvm_cell Cell;
 


### PR DESCRIPTION
Note that all examples are already moved to tvm_accept()