### PR TITLE
Merge sequence of constant stores into a bigger one

### DIFF
--- a/llvm/lib/Target/TVM/CMakeLists.txt
+++ b/llvm/lib/Target/TVM/CMakeLists.txt
@@ -37,6 +37,7 @@ add_llvm_target(TVMCodeGen
   TVMStackFixup.cpp
   TVMStackPatterns.cpp
   TVMStackModel.cpp
+  TVMStoreCombine.cpp
   TVMUtilities.cpp
   TVMContinuationsHoist.cpp
   TVMLoadStoreReplace.cpp

--- a/llvm/lib/Target/TVM/TVM.h
+++ b/llvm/lib/Target/TVM/TVM.h
@@ -41,6 +41,7 @@ FunctionPass *createTVMLoopPrepare();
 FunctionPass *createTVMContinuationsHoist();
 FunctionPass *createTVMIfConversionTerm();
 BasicBlockPass *createTVMLoadStoreReplace();
+BasicBlockPass *createTVMStoreCombine();
 
 void initializeTVMArgumentMovePass(PassRegistry &);
 void initializeTVMControlFlowPreparePass(PassRegistry &);
@@ -56,6 +57,7 @@ void initializeTVMLoopPreparePass(PassRegistry &);
 void initializeTVMContinuationsHoistPass(PassRegistry &);
 void initializeTVMLoadStoreReplacePass(PassRegistry &);
 void initializeTVMIfConversionTermPass(PassRegistry &);
+void initializeTVMStoreCombinePass(PassRegistry &);
 
 } // namespace llvm
 

--- a/llvm/lib/Target/TVM/TVMStoreCombine.cpp
+++ b/llvm/lib/Target/TVM/TVMStoreCombine.cpp
@@ -1,0 +1,177 @@
+//===------- TVMStoreCombine.cpp - Combine STU / STI with constants -------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implement pass for merging multiple STU / STI with const argument into
+/// a bigger STU / STI.
+///
+//===----------------------------------------------------------------------===//
+
+#include <vector>
+
+#include "TVM.h"
+#include "llvm/Analysis/LoopInfo.h"
+#include "llvm/Analysis/LoopPass.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Operator.h"
+#include "llvm/Pass.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Transforms/Utils/Local.h"
+#include "llvm/Transforms/Utils/ModuleUtils.h"
+using namespace llvm;
+
+#define DEBUG_TYPE "tvm-store-combine"
+
+namespace {
+class TVMStoreCombine final : public BasicBlockPass {
+  StringRef getPassName() const override {
+    return "Combine STU / STI instructions";
+  }
+
+  void getAnalysisUsage(AnalysisUsage &AU) const override {
+    AU.setPreservesAll();
+  }
+
+  bool runOnBasicBlock(BasicBlock &BB) override;
+
+public:
+  static char ID;
+  explicit TVMStoreCombine() : BasicBlockPass(ID) {}
+};
+} // End anonymous namespace
+
+char TVMStoreCombine::ID = 0;
+INITIALIZE_PASS(TVMStoreCombine, DEBUG_TYPE, "Combine STU and STI intrinsics",
+                false, false)
+
+BasicBlockPass *llvm::createTVMStoreCombine() { return new TVMStoreCombine(); }
+
+/// Size limit for single Store.
+/// Note that 257-bit stores are possible, but they need 2 instructions to be
+/// generated.
+static const unsigned SizeLimit = 256;
+
+/// Provide call site for STI or STU.
+/// Default constructed call site is returned if the instruction is not STI/STU.
+static CallSite storeConstCallSite(Instruction *I) {
+  auto CS = CallSite(I);
+  if (!CS)
+    return CS;
+  if ((CS.getIntrinsicID() == Intrinsic::tvm_stu ||
+       CS.getIntrinsicID() == Intrinsic::tvm_sti) &&
+      isa<ConstantInt>(CS.getArgument(0)) &&
+      isa<ConstantInt>(CS.getArgument(2)))
+    return CS;
+  return {};
+}
+
+enum class CanCombine {
+  No,
+  Yes,
+  Last // Can combine, but no more stores can be added.
+};
+
+/// \brief Determine whether current STI / STU instruction can be merged with
+/// previous ones.
+/// \param size total size of STI / STU arguments preceeding \p CS that are
+/// supposed to be merged.
+/// \return flag if the instruction can be merged.
+static CanCombine canCombine(unsigned Size, CallSite &CS) {
+  auto *Op0 = dyn_cast<ConstantInt>(CS.getArgument(0));
+  if (!Op0)
+    return CanCombine::No;
+  auto *Op2 = dyn_cast<ConstantInt>(CS.getArgument(2));
+  if (!Op2)
+    return CanCombine::No;
+  if (Size + Op2->getZExtValue() > SizeLimit)
+    return CanCombine::No;
+  if (CS.getInstruction()->getNumUses() > 1u)
+    return CanCombine::Last;
+  return CanCombine::Yes;
+}
+
+/// \brief Combine STU / STI instructions in the given range.
+static void combine(BasicBlock::iterator Start, BasicBlock::iterator End) {
+  unsigned Size = 0;
+  APInt Data(257, 0, false);
+  auto It = Start;
+  std::vector<Instruction *> RemoveInst;
+  for (; It != End; ++It) {
+    auto CS = CallSite(&*It);
+    APInt Val = cast<ConstantInt>(CS.getArgument(0))->getValue();
+    unsigned Sz = cast<ConstantInt>(CS.getArgument(2))->getZExtValue();
+    if (Val.slt(0)) {
+      APInt Pow2(257, 0, false);
+      Pow2.setBit(Sz);
+      Val = Pow2 - Val;
+    }
+    Data <<= Sz;
+    Size += Sz;
+    Data |= Val;
+    RemoveInst.push_back(&*It);
+  }
+  auto *BuilderArg = CallSite(&*Start).getArgument(1);
+  IRBuilder<> Builder(&*It);
+  std::vector<Value *> Args{Builder.getInt(Data), BuilderArg,
+                            Builder.getIntN(257, Size)};
+  auto *Fn = Intrinsic::getDeclaration(It->getModule(), Intrinsic::tvm_stu);
+  auto *Inst = Builder.CreateCall(Fn, Args);
+  std::prev(std::prev(It))->replaceAllUsesWith(Inst);
+  for (auto It = RemoveInst.rbegin(), E = RemoveInst.rend(); It != E; ++It)
+    (*It)->eraseFromParent();
+}
+
+/// Try merge STU / STI calls starting from It.
+/// \param It iterator of STI or STU intrinsic call.
+/// \return iterator pointing at one instruction after the merged STI or STU.
+/// TODO: better is to implement not as a peephole, but as def-use walk.
+static BasicBlock::iterator tryCombine(BasicBlock::iterator Start,
+                                       BasicBlock::iterator End) {
+  assert(Start != End);
+  auto CS = CallSite(&*Start);
+  unsigned Size = cast<ConstantInt>(CS.getArgument(2))->getZExtValue();
+  auto It = std::next(Start), Prev = Start;
+  bool Combinable = false;
+  for (; It != End; Prev = It++) {
+    if (auto CurrentCS = storeConstCallSite(&*It)) {
+      CanCombine Status = canCombine(Size, CurrentCS);
+      if (Status != CanCombine::No && CallSite(&*It).getArgument(1) == &*Prev) {
+        Combinable = true;
+        Size += cast<ConstantInt>(CurrentCS.getArgument(2))->getZExtValue();
+        if (Status != CanCombine::Last)
+          continue;
+        It++;
+        break;
+      }
+    }
+    break;
+  }
+  if (Combinable)
+    combine(Start, It);
+  return It;
+}
+
+bool TVMStoreCombine::runOnBasicBlock(BasicBlock &BB) {
+  bool Changed = false;
+  auto It = BB.begin(), End = BB.end();
+  do {
+    It = std::find_if(It, End, [](Instruction &I) {
+      return static_cast<bool>(storeConstCallSite(&I));
+    });
+    if (It == End)
+      break;
+    auto Next = std::next(It);
+    It = tryCombine(It, End);
+    if (It != Next)
+      Changed = true;
+  } while (true);
+  return Changed;
+}

--- a/llvm/lib/Target/TVM/TVMTargetMachine.cpp
+++ b/llvm/lib/Target/TVM/TVMTargetMachine.cpp
@@ -43,6 +43,7 @@ extern "C" void LLVMInitializeTVMTarget() {
   initializeTVMLoopPreparePass(PR);
   initializeTVMContinuationsHoistPass(PR);
   initializeTVMLoadStoreReplacePass(PR);
+  initializeTVMStoreCombinePass(PR);
 }
 
 static Reloc::Model getEffectiveRelocModel(Optional<Reloc::Model> RM) {
@@ -128,6 +129,7 @@ void TVMPassConfig::addIRPasses() {
   addPass(createLowerSwitchPass());
   addPass(createTVMLoopPrepare());
   addPass(createTVMControlFlowPrepare());
+  addPass(createTVMStoreCombine());
 }
 
 bool TVMPassConfig::addInstSelector() {

--- a/llvm/test/CodeGen/TVM/store-opt.ll
+++ b/llvm/test/CodeGen/TVM/store-opt.ll
@@ -1,0 +1,50 @@
+; RUN: opt -tvm-store-combine -S < %s -march=tvm | FileCheck %s
+target datalayout = "E-S257-i1:257:257-i8:257:257-i16:257:257-i32:257:257-i64:257:257-i257:257:257-p:257:257-a:257:257"
+target triple = "tvm"
+
+; CHECK-LABEL: test1
+define builder @test1() {
+  %1 = call builder @llvm.tvm.newc()
+  %2 = call builder @llvm.tvm.stu(i257 7, builder %1, i257 5)
+  %3 = call builder @llvm.tvm.stu(i257 42, builder %2, i257 7)
+  ; CHECK: %[[VR1:[0-9]+]] = call builder @llvm.tvm.stu(i257 938, builder %{{[0-9]+}}, i257 12)
+  %4 = call builder @llvm.tvm.stu(i257 42, builder %3, i257 250)
+  %5 = call builder @llvm.tvm.stu(i257 2, builder %4, i257 6)
+  ; CHECK: %[[VR2:[0-9]+]] = call builder @llvm.tvm.stu(i257 2690, builder %[[VR1]], i257 256)
+  %6 = call builder @llvm.tvm.sti(i257 -1, builder %5, i257 1)
+  %7 = call builder @llvm.tvm.stu(i257 3, builder %6, i257 2)
+  %8 = call builder @llvm.tvm.sti(i257 -7, builder %7, i257 3)
+  ; CHECK: %[[VR3:[0-9]+]] = call builder @llvm.tvm.stu(i257 127, builder %[[VR2]], i257 6)
+  %9 = call builder @llvm.tvm.sti(i257 -7, builder %8, i257 251)
+  ; CHECK: %{{[0-9]+}} = call builder @llvm.tvm.sti(i257 -7, builder %[[VR3]], i257 251)
+  ret builder %9
+}
+
+; CHECK-LABEL: test2
+define builder @test2() {
+  %1 = call builder @llvm.tvm.newc()
+  %2 = call builder @llvm.tvm.newc()
+  %3 = call builder @llvm.tvm.stu(i257 7, builder %1, i257 5)
+  %4 = call builder @llvm.tvm.stu(i257 7, builder %3, i257 5)
+  ; CHECK: %{{[0-9]+}} = call builder @llvm.tvm.stu(i257 231, builder %1, i257 10)
+  %5 = call builder @llvm.tvm.stu(i257 7, builder %2, i257 5)
+  ; CHECK: %{{[0-9]+}} = call builder @llvm.tvm.stu(i257 7, builder %2, i257 5)
+  ret builder %4
+}
+
+; CHECK-LABEL: test3
+define builder @test3() {
+  %1 = call builder @llvm.tvm.newc()
+  %2 = call builder @llvm.tvm.stu(i257 1, builder %1, i257 1)
+  %3 = call builder @llvm.tvm.stu(i257 1, builder %2, i257 1)
+  ; CHECK: %[[VR:[0-9]+]] = call builder @llvm.tvm.stu(i257 3, builder %{{[0-9]+}}, i257 2)
+  %4 = call builder @llvm.tvm.stu(i257 1, builder %3, i257 1)
+  ; CHECK: %{{[0-9]+}} = call builder @llvm.tvm.stu(i257 1, builder %[[VR]], i257 1)
+  %5 = call builder @llvm.tvm.stu(i257 1, builder %3, i257 1)
+  ; CHECK: %{{[0-9]+}} = call builder @llvm.tvm.stu(i257 1, builder %[[VR]], i257 1)
+  ret builder %5
+}
+
+declare builder @llvm.tvm.newc()
+declare builder @llvm.tvm.stu(i257, builder, i257)
+declare builder @llvm.tvm.sti(i257, builder, i257)


### PR DESCRIPTION
When a basic block contain two consequitive stores of some constants to
a builder, the pass merges them together.

Notes:
- The pass is currently work as a peephole optimization, which
should work for the most of real life use cases. It's better though to
walk through use-def chains and merge instructions that have one use.
- Variable int stores optimization is out of the scope of this patch.