### PR TITLE
Fix timestamp replay attack protection

### DIFF
--- a/stdlib/cpp-sdk/tvm/replay_attack_protection/timestamp.hpp
+++ b/stdlib/cpp-sdk/tvm/replay_attack_protection/timestamp.hpp
@@ -20,7 +20,7 @@ public:
   static inline std::optional<persistent_t> check(unsigned msg_time, persistent_t last) {
     if (last && msg_time <= last)
       return {};
-    if (msg_time >= smart_contract_info::now() + Interval)
+    if (msg_time >= (smart_contract_info::now() + Interval) * 1000)
       return {};
     return persistent_t{msg_time};
   }


### PR DESCRIPTION
The timestamp is in milliseconds while NOW return time in seconds.