### PR TITLE
Support for token contracts

### DIFF
--- a/llvm/lib/Target/TVM/TVMStackFixup.cpp
+++ b/llvm/lib/Target/TVM/TVMStackFixup.cpp
@@ -354,10 +354,13 @@ StackFixup StackFixup::DiffForArgs(const Stack &From, const MIArgs &Args,
 
   bool HasBigNums = false;
   SmallVector<argInfo, 4> ArgInfo;
+  unsigned PushOffset = 0; // offset by previous pushes
   for (unsigned i = 0; i < Args.size(); ++i) {
     ArgInfo.push_back(argInfo(Args, i, CurStack));
-    if (ArgInfo.back().SrcPos > XchgLimit)
+    if (PushOffset + ArgInfo.back().SrcPos > XchgLimit)
       HasBigNums = true;
+    if (ArgInfo.back().Push)
+      ++PushOffset;
   }
   bool AlreadyGood = true;
   for (unsigned i = 0; i < Args.size(); ++i) {

--- a/llvm/tools/clang/include/clang/AST/ASTContext.h
+++ b/llvm/tools/clang/include/clang/AST/ASTContext.h
@@ -350,6 +350,10 @@ class ASTContext : public RefCountedBase<ASTContext> {
   mutable IdentifierInfo *ReflectMethodExternalName = nullptr;
   /// The identifier '__reflect_method_getter'.
   mutable IdentifierInfo *ReflectMethodGetterName = nullptr;
+  /// The identifier '__reflect_method_noaccept'.
+  mutable IdentifierInfo *ReflectMethodNoAcceptName = nullptr;
+  /// The identifier '__reflect_method_dyn_chain_parse'.
+  mutable IdentifierInfo *ReflectMethodDynChainParseName = nullptr;
   /// The identifier '__reflect_method_no_read_persistent'.
   mutable IdentifierInfo *ReflectMethodNoReadPersistentName = nullptr;
   /// The identifier '__reflect_method_no_write_persistent'.
@@ -360,6 +364,8 @@ class ASTContext : public RefCountedBase<ASTContext> {
   mutable IdentifierInfo *ReflectMethodRvName = nullptr;
   /// The identifier '__reflect_method_arg_struct'.
   mutable IdentifierInfo *ReflectMethodArgStructName = nullptr;
+  /// The identifier '__reflect_method_ptr_arg_struct'.
+  mutable IdentifierInfo *ReflectMethodPtrArgStructName = nullptr;
   /// The identifier '__reflect_smart_interface'.
   mutable IdentifierInfo *ReflectSmartInterfaceName = nullptr;
   /// The identifier '__reflect_method_ptr'.
@@ -554,11 +560,14 @@ private:
   mutable BuiltinTemplateDecl *ReflectMethodInternalDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodExternalDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodGetterDecl = nullptr;
+  mutable BuiltinTemplateDecl *ReflectMethodNoAcceptDecl = nullptr;
+  mutable BuiltinTemplateDecl *ReflectMethodDynChainParseDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodNoReadPersistentDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodNoWritePersistentDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodPtrFuncIdDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodRvDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodArgStructDecl = nullptr;
+  mutable BuiltinTemplateDecl *ReflectMethodPtrArgStructDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectSmartInterfaceDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodPtrDecl = nullptr;
   // TVM local end
@@ -1073,11 +1082,14 @@ public:
   BuiltinTemplateDecl *getReflectMethodInternalDecl() const;
   BuiltinTemplateDecl *getReflectMethodExternalDecl() const;
   BuiltinTemplateDecl *getReflectMethodGetterDecl() const;
+  BuiltinTemplateDecl *getReflectMethodNoAcceptDecl() const;
+  BuiltinTemplateDecl *getReflectMethodDynChainParseDecl() const;
   BuiltinTemplateDecl *getReflectMethodNoReadPersistentDecl() const;
   BuiltinTemplateDecl *getReflectMethodNoWritePersistentDecl() const;
   BuiltinTemplateDecl *getReflectMethodPtrFuncIdDecl() const;
   BuiltinTemplateDecl *getReflectMethodRvDecl() const;
   BuiltinTemplateDecl *getReflectMethodArgStructDecl() const;
+  BuiltinTemplateDecl *getReflectMethodPtrArgStructDecl() const;
   BuiltinTemplateDecl *getReflectSmartInterfaceDecl() const;
   BuiltinTemplateDecl *getReflectMethodPtrDecl() const;
   // TVM local end
@@ -1446,9 +1458,9 @@ public:
                                        StringRef ElemsStr) const;
 
   /// Creating struct with combined arguments for Method (without `this`)
-  QualType prepareTVMArgumentsStructType(CXXMethodDecl *Method,
+  QualType prepareTVMArgumentsStructType(const CXXMethodDecl *Method,
                                          SourceLocation Loc) const;
-  QualType getTVMArgumentsStructType(CXXMethodDecl *Method,
+  QualType getTVMArgumentsStructType(const CXXMethodDecl *Method,
                                      SourceLocation Loc) const;
 
   /// Creating struct with adapted smart interface for contract interface
@@ -1886,6 +1898,18 @@ public:
     return ReflectMethodGetterName;
   }
 
+  IdentifierInfo *getReflectMethodNoAcceptName() const {
+    if (!ReflectMethodNoAcceptName)
+      ReflectMethodNoAcceptName = &Idents.get("__reflect_method_noaccept");
+    return ReflectMethodNoAcceptName;
+  }
+
+  IdentifierInfo *getReflectMethodDynChainParseName() const {
+    if (!ReflectMethodDynChainParseName)
+      ReflectMethodDynChainParseName = &Idents.get("__reflect_method_dyn_chain_parse");
+    return ReflectMethodDynChainParseName;
+  }
+
   IdentifierInfo *getReflectMethodNoReadPersistentName() const {
     if (!ReflectMethodNoReadPersistentName)
       ReflectMethodNoReadPersistentName =
@@ -1916,6 +1940,12 @@ public:
     if (!ReflectMethodArgStructName)
       ReflectMethodArgStructName = &Idents.get("__reflect_method_arg_struct");
     return ReflectMethodArgStructName;
+  }
+
+  IdentifierInfo *getReflectMethodPtrArgStructName() const {
+    if (!ReflectMethodPtrArgStructName)
+      ReflectMethodPtrArgStructName = &Idents.get("__reflect_method_ptr_arg_struct");
+    return ReflectMethodPtrArgStructName;
   }
 
   IdentifierInfo *getReflectSmartInterfaceName() const {

--- a/llvm/tools/clang/include/clang/Basic/Attr.td
+++ b/llvm/tools/clang/include/clang/Basic/Attr.td
@@ -1670,6 +1670,16 @@ def TVMGetterFunc : Attr {
   let Documentation = [Undocumented];
   let Subjects = SubjectList<[Function]>;
 }
+def TVMNoAcceptFunc : Attr {
+  let Spellings = [Clang<"noaccept">];
+  let Documentation = [Undocumented];
+  let Subjects = SubjectList<[Function]>;
+}
+def TVMDynChainParseFunc : Attr {
+  let Spellings = [Clang<"dyn_chain_parse">];
+  let Documentation = [Undocumented];
+  let Subjects = SubjectList<[Function]>;
+}
 def TVMNoReadPersistentFunc : Attr {
   let Spellings = [Clang<"no_read_persistent">];
   let Documentation = [Undocumented];

--- a/llvm/tools/clang/include/clang/Basic/Builtins.h
+++ b/llvm/tools/clang/include/clang/Basic/Builtins.h
@@ -272,6 +272,12 @@ enum BuiltinTemplateKind : int {
   /// This names the __reflect_method_getter BuiltinTemplateDecl.
   BTK__reflect_method_getter,
 
+  /// This names the __reflect_method_noaccept BuiltinTemplateDecl.
+  BTK__reflect_method_noaccept,
+
+  /// This names the __reflect_method_dyn_chain_parse BuiltinTemplateDecl.
+  BTK__reflect_method_dyn_chain_parse,
+
   /// This names the __reflect_method_no_read_persistent BuiltinTemplateDecl.
   BTK__reflect_method_no_read_persistent,
 
@@ -286,6 +292,9 @@ enum BuiltinTemplateKind : int {
 
   /// This names the __reflect_method_arg_struct BuiltinTemplateDecl.
   BTK__reflect_method_arg_struct,
+
+  /// This names the __reflect_method_ptr_arg_struct BuiltinTemplateDecl.
+  BTK__reflect_method_ptr_arg_struct,
 
   /// This names the __reflect_smart_interface BuiltinTemplateDecl.
   BTK__reflect_smart_interface,

--- a/llvm/tools/clang/lib/AST/ASTContext.cpp
+++ b/llvm/tools/clang/lib/AST/ASTContext.cpp
@@ -1108,6 +1108,22 @@ ASTContext::getReflectMethodGetterDecl() const {
 }
 
 BuiltinTemplateDecl *
+ASTContext::getReflectMethodNoAcceptDecl() const {
+  if (!ReflectMethodNoAcceptDecl)
+    ReflectMethodNoAcceptDecl = buildBuiltinTemplateDecl(
+        BTK__reflect_method_noaccept, getReflectMethodNoAcceptName());
+  return ReflectMethodNoAcceptDecl;
+}
+
+BuiltinTemplateDecl *
+ASTContext::getReflectMethodDynChainParseDecl() const {
+  if (!ReflectMethodDynChainParseDecl)
+    ReflectMethodDynChainParseDecl = buildBuiltinTemplateDecl(
+        BTK__reflect_method_dyn_chain_parse, getReflectMethodDynChainParseName());
+  return ReflectMethodDynChainParseDecl;
+}
+
+BuiltinTemplateDecl *
 ASTContext::getReflectMethodNoReadPersistentDecl() const {
   if (!ReflectMethodNoReadPersistentDecl)
     ReflectMethodNoReadPersistentDecl = buildBuiltinTemplateDecl(
@@ -1147,6 +1163,14 @@ ASTContext::getReflectMethodArgStructDecl() const {
     ReflectMethodArgStructDecl = buildBuiltinTemplateDecl(
         BTK__reflect_method_arg_struct, getReflectMethodArgStructName());
   return ReflectMethodArgStructDecl;
+}
+
+BuiltinTemplateDecl *
+ASTContext::getReflectMethodPtrArgStructDecl() const {
+  if (!ReflectMethodPtrArgStructDecl)
+    ReflectMethodPtrArgStructDecl = buildBuiltinTemplateDecl(
+        BTK__reflect_method_ptr_arg_struct, getReflectMethodPtrArgStructName());
+  return ReflectMethodPtrArgStructDecl;
 }
 
 BuiltinTemplateDecl *
@@ -3684,7 +3708,7 @@ QualType ASTContext::prepareTVMLiteralStructType(ArrayRef<QualType> Elems,
   return getTypeDeclType(TypedefDec);
 }
 
-QualType ASTContext::getTVMArgumentsStructType(CXXMethodDecl *Method,
+QualType ASTContext::getTVMArgumentsStructType(const CXXMethodDecl *Method,
                                                SourceLocation Loc) const {
   auto it = TVMMethodArgStructs.find(Method);
   if (it != TVMMethodArgStructs.end())
@@ -3697,7 +3721,7 @@ QualType ASTContext::getTVMArgumentsStructType(CXXMethodDecl *Method,
 
 /// Creating struct with combined arguments for Method (no `this`)
 QualType
-ASTContext::prepareTVMArgumentsStructType(CXXMethodDecl *Method,
+ASTContext::prepareTVMArgumentsStructType(const CXXMethodDecl *Method,
                                           SourceLocation Loc) const {
   auto StructName = ("__tvm_arguments_struct_" + Method->getName()).str();
   auto *RecDecl = buildImplicitRecord(StructName + "_Tag", TTK_Struct, Loc);

--- a/llvm/tools/clang/lib/AST/DeclTemplate.cpp
+++ b/llvm/tools/clang/lib/AST/DeclTemplate.cpp
@@ -1445,6 +1445,20 @@ static TemplateParameterList *
 createReflectMethodGetterParameterList(const ASTContext &C, DeclContext *DC) {
   return createReflectMethodIntegralConstantParameterList(C, DC);
 }
+// __reflect_method_noaccept<T, IntType, Interface, Index> -
+//   'noaccept' attribute of the Interface method number #Index,
+//   provided into T<IntType, isInternal>
+static TemplateParameterList *
+createReflectMethodNoAcceptParameterList(const ASTContext &C, DeclContext *DC) {
+  return createReflectMethodIntegralConstantParameterList(C, DC);
+}
+// __reflect_method_dyn_chain_parse<T, IntType, Interface, Index> -
+//   'dyn_chain_parse' attribute of the Interface method number #Index,
+//   provided into T<IntType, isInternal>
+static TemplateParameterList *
+createReflectMethodDynChainParseParameterList(const ASTContext &C, DeclContext *DC) {
+  return createReflectMethodIntegralConstantParameterList(C, DC);
+}
 // __reflect_method_no_read_persistent<T, IntType, Interface, Index> -
 //   'no_read_persistent' attribute of the Interface method number #Index,
 //   provided into T<IntType, isInternal>
@@ -1549,6 +1563,24 @@ createReflectMethodArgStructParameterList(const ASTContext &C, DeclContext *DC) 
   Index->setImplicit(true);
 
   NamedDecl *Params[] = { Interface, Index };
+  return TemplateParameterList::Create(C, SourceLocation(), SourceLocation(),
+                                       llvm::makeArrayRef(Params),
+                                       SourceLocation(), nullptr);
+}
+
+// __reflect_method_ptr_arg_struct<Rv Interface::* MethodPtr> -
+//   Combined arguments structure of the MethodPtr
+static TemplateParameterList *
+createReflectMethodPtrArgStructParameterList(const ASTContext &C, DeclContext *DC) {
+  // Rv Interface::* MethodPtr
+  QualType AutoType = C.getAutoDeductType();
+  TypeSourceInfo *TInfo = C.getTrivialTypeSourceInfo(AutoType);
+  auto *MethodPtr = NonTypeTemplateParmDecl::Create(
+      C, DC, SourceLocation(), SourceLocation(), /*Depth=*/0, /*Position=*/0,
+      /*Id=*/nullptr, TInfo->getType(), /*ParameterPack=*/false, TInfo);
+  MethodPtr->setImplicit(true);
+
+  NamedDecl *Params[] = { MethodPtr };
   return TemplateParameterList::Create(C, SourceLocation(), SourceLocation(),
                                        llvm::makeArrayRef(Params),
                                        SourceLocation(), nullptr);
@@ -1669,6 +1701,10 @@ static TemplateParameterList *createBuiltinTemplateParameterList(
     return createReflectMethodExternalParameterList(C, DC);
   case BTK__reflect_method_getter:
     return createReflectMethodGetterParameterList(C, DC);
+  case BTK__reflect_method_noaccept:
+    return createReflectMethodNoAcceptParameterList(C, DC);
+  case BTK__reflect_method_dyn_chain_parse:
+    return createReflectMethodDynChainParseParameterList(C, DC);
   case BTK__reflect_method_no_read_persistent:
     return createReflectMethodNoReadPersistentParameterList(C, DC);
   case BTK__reflect_method_no_write_persistent:
@@ -1679,6 +1715,8 @@ static TemplateParameterList *createBuiltinTemplateParameterList(
     return createReflectMethodRvParameterList(C, DC);
   case BTK__reflect_method_arg_struct:
     return createReflectMethodArgStructParameterList(C, DC);
+  case BTK__reflect_method_ptr_arg_struct:
+    return createReflectMethodPtrArgStructParameterList(C, DC);
   case BTK__reflect_smart_interface:
     return createReflectSmartInterfaceParameterList(C, DC);
   case BTK__reflect_method_ptr:

--- a/llvm/tools/clang/lib/CodeGen/CodeGenTypes.cpp
+++ b/llvm/tools/clang/lib/CodeGen/CodeGenTypes.cpp
@@ -727,11 +727,15 @@ llvm::StructType *CodeGenTypes::ConvertRecordDeclType(const RecordDecl *RD) {
   // type connected to the decl.
   const Type *Key = Context.getTagDeclType(RD).getTypePtr();
 
-  llvm::StructType *&Entry = RecordDeclTypes[Key];
+  // TVM local begin
+  llvm::StructType *Entry = RecordDeclTypes[Key];
+  // TVM local end
 
   // If we don't have a StructType at all yet, create the forward declaration.
   if (!Entry) {
-    Entry = llvm::StructType::create(getLLVMContext());
+    // TVM local begin
+    RecordDeclTypes[Key] = Entry = llvm::StructType::create(getLLVMContext());
+    // TVM local end
     addRecordTypeName(RD, Entry, "");
   }
   llvm::StructType *Ty = Entry;
@@ -747,6 +751,9 @@ llvm::StructType *CodeGenTypes::ConvertRecordDeclType(const RecordDecl *RD) {
         !Ty->isLiteral()) {
       Entry = Ty = llvm::StructType::get(Ty->getContext(), Ty->elements(),
                                          Ty->isPacked());
+      // TVM local begin
+      RecordDeclTypes[Key] = Entry;
+      // TVM local end
       CGRecordLayouts[Key]->updateToLiteralType(Ty);
     }
     return Ty;
@@ -798,6 +805,7 @@ llvm::StructType *CodeGenTypes::ConvertRecordDeclType(const RecordDecl *RD) {
   if (RD->isLiteral() || RD->hasAttr<TVMTupleStructAttr>()) {
     Entry = Ty = llvm::StructType::get(Ty->getContext(), Ty->elements(),
                                        Ty->isPacked());
+    RecordDeclTypes[Key] = Entry;
     CGRecordLayouts[Key]->updateToLiteralType(Ty);
   }
   // TVM local end

--- a/llvm/tools/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/llvm/tools/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6393,6 +6393,12 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
     // Applying also no_write_persistent for getter methods
     handleSimpleAttribute<TVMNoWritePersistentFuncAttr>(S, D, AL);
     break;
+  case ParsedAttr::AT_TVMNoAcceptFunc:
+    handleSimpleAttribute<TVMNoAcceptFuncAttr>(S, D, AL);
+    break;
+  case ParsedAttr::AT_TVMDynChainParseFunc:
+    handleSimpleAttribute<TVMDynChainParseFuncAttr>(S, D, AL);
+    break;
   case ParsedAttr::AT_TVMNoReadPersistentFunc:
     handleSimpleAttribute<TVMNoReadPersistentFuncAttr>(S, D, AL);
     break;

--- a/llvm/tools/clang/lib/Sema/SemaLookup.cpp
+++ b/llvm/tools/clang/lib/Sema/SemaLookup.cpp
@@ -713,6 +713,12 @@ static bool LookupBuiltin(Sema &S, LookupResult &R) {
         } else if (II == S.getASTContext().getReflectMethodGetterName()) {
           R.addDecl(S.getASTContext().getReflectMethodGetterDecl());
           return true;
+        } else if (II == S.getASTContext().getReflectMethodNoAcceptName()) {
+          R.addDecl(S.getASTContext().getReflectMethodNoAcceptDecl());
+          return true;
+        } else if (II == S.getASTContext().getReflectMethodDynChainParseName()) {
+          R.addDecl(S.getASTContext().getReflectMethodDynChainParseDecl());
+          return true;
         } else if (II == S.getASTContext().getReflectMethodNoReadPersistentName()) {
           R.addDecl(S.getASTContext().getReflectMethodNoReadPersistentDecl());
           return true;
@@ -727,6 +733,9 @@ static bool LookupBuiltin(Sema &S, LookupResult &R) {
           return true;
         } else if (II == S.getASTContext().getReflectMethodArgStructName()) {
           R.addDecl(S.getASTContext().getReflectMethodArgStructDecl());
+          return true;
+        } else if (II == S.getASTContext().getReflectMethodPtrArgStructName()) {
+          R.addDecl(S.getASTContext().getReflectMethodPtrArgStructDecl());
           return true;
         } else if (II == S.getASTContext().getReflectSmartInterfaceName()) {
           R.addDecl(S.getASTContext().getReflectSmartInterfaceDecl());

--- a/llvm/tools/clang/lib/Sema/SemaOverload.cpp
+++ b/llvm/tools/clang/lib/Sema/SemaOverload.cpp
@@ -11940,11 +11940,13 @@ bool Sema::buildOverloadedCallSet(Scope *S, Expr *Fn,
     // We don't perform ADL for implicit declarations of builtins.
     // Verify that this was correctly set up.
     FunctionDecl *F;
-    if (ULE->decls_begin() + 1 == ULE->decls_end() &&
-        (F = dyn_cast<FunctionDecl>(*ULE->decls_begin())) &&
-        F->getBuiltinID() && F->isImplicit())
-      llvm_unreachable("performing ADL for builtin");
-
+    // TVM local begin
+    if (ULE->decls_begin() != ULE->decls_end())
+      if (ULE->decls_begin() + 1 == ULE->decls_end() &&
+          (F = dyn_cast<FunctionDecl>(*ULE->decls_begin())) &&
+          F->getBuiltinID() && F->isImplicit())
+        llvm_unreachable("performing ADL for builtin");
+    // TVM local end
     // We don't perform ADL in C.
     assert(getLangOpts().CPlusPlus && "ADL enabled in C");
   }

--- a/llvm/tools/clang/test/CodeGen/tvm/dyn_chain_parser_test.cpp
+++ b/llvm/tools/clang/test/CodeGen/tvm/dyn_chain_parser_test.cpp
@@ -1,0 +1,61 @@
+// RUN: %clang -O3 -S -c -emit-llvm -target tvm %s --sysroot=%S/../../../../../../stdlib -o -
+// REQUIRES: tvm-registered-target
+
+#include <tvm/chain_builder.hpp>
+#include <tvm/assert.hpp>
+#include <tvm/schema/json-abi-gen.hpp>
+
+using namespace tvm;
+using namespace schema;
+
+__interface IDynContract {
+  __attribute__((external))
+  void constructor(bytes name, bytes symbol, uint8 decimals, uint256 root_public_key, cell wallet_code, uint256 total_supply) = 1;
+};
+struct DDynContract {};
+struct EDynContract {};
+
+DEFINE_JSON_ABI(IDynContract, DDynContract, EDynContract);
+
+struct Args {
+  bytes name;
+  bytes symbol;
+  uint8 decimals;
+  uint256 root_public_key;
+  cell wallet_code;
+  uint256 total_supply;
+};
+
+__always_inline uint256 test1(slice sl) {
+  parser p(sl);
+  Args args = parse_chain_dynamic<Args>(p);
+  return args.total_supply;
+}
+
+__attribute__((tvm_raw_func))
+int main_external(__tvm_cell msg, __tvm_slice msg_body) {
+  parser p(msg_body);
+  require(p.ldu(32) == 1, error_code::wrong_public_call);
+  unsigned timestamp = p.ldu(64); // reading timestamp
+  p.ldref(); // reading signature reference
+
+  return test1(p.sl()).get();
+}
+
+__attribute__((tvm_raw_func)) int main_internal(__tvm_cell msg, __tvm_slice msg_body) {
+  tvm_throw(error_code::unsupported_call_method);
+  return 0;
+}
+__attribute__((tvm_raw_func)) int main_ticktock(__tvm_cell msg, __tvm_slice msg_body) {
+  tvm_throw(error_code::unsupported_call_method);
+  return 0;
+}
+__attribute__((tvm_raw_func)) int main_split(__tvm_cell msg, __tvm_slice msg_body) {
+  tvm_throw(error_code::unsupported_call_method);
+  return 0;
+}
+__attribute__((tvm_raw_func)) int main_merge(__tvm_cell msg, __tvm_slice msg_body) {
+  tvm_throw(error_code::unsupported_call_method);
+  return 0;
+}
+

--- a/llvm/tools/clang/test/CodeGen/tvm/struct_arg_big.c
+++ b/llvm/tools/clang/test/CodeGen/tvm/struct_arg_big.c
@@ -17,7 +17,7 @@ static int g(big_struct v) {
   return v.a + v.b + v.c + v.d + v.e + v.f + v.g + v.h;
 }
 
-// CHECK: call fastcc i257 @g(i257 %v1, i257 %v2, i257 %v3, i257 %v4, i257 %v5, i257 %v6, i257 %v7, i257 %v8)
+// CHECK: call fastcc i257 @g(i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}})
 int main_func(int v1, int v2, int v3, int v4, int v5, int v6, int v7, int v8) {
   big_struct big = { v1, v2, v3, v4, v5, v6, v7, v8 };
   int rv = g(big);

--- a/llvm/tools/clang/test/CodeGen/tvm/test_union_with_bool.cpp
+++ b/llvm/tools/clang/test/CodeGen/tvm/test_union_with_bool.cpp
@@ -38,17 +38,17 @@ union test_union {
   delta d;
 };
 
-// CHECK: @_Z18test_argument_beta10test_union(i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}})
+// CHECK: @_Z18test_argument_beta10test_union(i257{{( %.*)?}}, i257{{( %.*)?}}, i257{{( %.*)?}}, i257{{( %.*)?}}, i257{{( %.*)?}}, i257{{( %.*)?}}, i257{{( %.*)?}}, i257{{( %.*)?}}, i257{{( %.*)?}})
 __attribute__((noinline)) int test_argument_beta(test_union v) {
   return v.b.b_v0 + v.b.b_v1 + (int)v.b.b_v2;
 }
 
-// CHECK: @_Z19test_argument_gamma10test_union(i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}})
+// CHECK: @_Z19test_argument_gamma10test_union(i257{{( %.*)?}}, i257{{( %.*)?}}, i257{{( %.*)?}}, i257{{( %.*)?}}, i257{{( %.*)?}}, i257{{( %.*)?}}, i257{{( %.*)?}}, i257{{( %.*)?}}, i257{{( %.*)?}})
 __attribute__((noinline)) int test_argument_gamma(test_union v) {
   return v.g.g_v0 + (int)v.g.g_v1 + (int)v.g.g_v2 + v.g.g_v3;
 }
 
-// CHECK: @_Z19test_argument_delta10test_union(i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}}, i257 %{{.*}})
+// CHECK: @_Z19test_argument_delta10test_union(i257{{( %.*)?}}, i257{{( %.*)?}}, i257{{( %.*)?}}, i257{{( %.*)?}}, i257{{( %.*)?}}, i257{{( %.*)?}}, i257{{( %.*)?}}, i257{{( %.*)?}}, i257{{( %.*)?}})
 __attribute__((noinline)) int test_argument_delta(test_union v) {
   auto [val, new_sl] = __builtin_tvm_ldu(v.d.d_v1, 8);
   return v.d.d_v0 + val;
@@ -74,7 +74,7 @@ int test_argument_delta_call(__tvm_slice sl) {
   test_union v;
   delta d = { 111, sl };
   v.d = d;
-  // CHECK: call i257 @_Z19test_argument_delta10test_union(i257 111, i257 %0
+  // CHECK: call i257 @_Z19test_argument_delta10test_union(i257 111, i257 %
   return test_argument_delta(v);
 }
 

--- a/stdlib/cpp-sdk/tvm/chain_builder.hpp
+++ b/stdlib/cpp-sdk/tvm/chain_builder.hpp
@@ -1,12 +1,25 @@
 #pragma once
 
 #include <tvm/schema/estimate_element.hpp>
+#include <tvm/builder.hpp>
+#include <tvm/parser.hpp>
+#include <tvm/schema/make_builder.hpp>
+#include <tvm/schema/make_parser.hpp>
+
+#include <tvm/to_struct.hpp>
+#include <tvm/error_code.hpp>
+#include <tvm/assert.hpp>
+#include <tvm/sequence.hpp>
 
 #include <boost/hana/take_front.hpp>
 #include <boost/hana/take_back.hpp>
 #include <boost/hana/ext/std/tuple.hpp>
 
+#include <experimental/type_traits>
+
 namespace tvm {
+
+namespace hana = boost::hana;
 
 // extract tuple format elements, that will for sure fit into Bits and Refs (when serialized)
 template<unsigned Bits, unsigned Refs, unsigned Idx, class Elem, class... Elems>
@@ -28,18 +41,56 @@ struct extract_fit<Bits, Refs, Idx, Elem> {
       std::integral_constant<unsigned, Idx>>::value;
 };
 
+template<class T>
+struct has_fmt_tuple {
+  using fmt_tuple = typename schema::make_builder_impl<T>::fmt_tuple;
+};
+template<class T>
+struct is_expandable : std::experimental::is_detected<has_fmt_tuple, T> {};
 template<class... Elems>
-static __always_inline cell build_chain(std::tuple<Elems...> tup) {
-  static constexpr unsigned fit_count = extract_fit<cell::max_bits, cell::max_refs - 1, 0, Elems...>::value;
-  static_assert(fit_count > 0, "Can't place even 1 sequence element into cell");
-    
-  auto cur_subtup = hana::take_front_c<fit_count>(tup);
-  builder b = schema::build(cur_subtup);
-  if constexpr (sizeof...(Elems) > fit_count) {
-    auto next_subtup = hana::take_back_c<sizeof...(Elems) - fit_count>(tup);
-    b.stref(build_chain(next_subtup));
+struct is_expandable<std::tuple<Elems...>> : std::true_type {};
+
+template<class T>
+struct is_optional : std::false_type {};
+template<class T>
+struct is_optional<std::optional<T>> : std::true_type {};
+
+template<class... Elems>
+static __always_inline builder build_chain(std::tuple<Elems...> tup) {
+  if constexpr (sizeof...(Elems) == 0) {
+    return {};
+  } else {
+    static constexpr unsigned fit_count = extract_fit<cell::max_bits, cell::max_refs - 1, 0, Elems...>::value;
+    if constexpr (fit_count == 0) {
+      // expanding first element
+      auto first_elem = std::get<0>(tup);
+      using first_elem_t = decltype(first_elem);
+      static_assert(is_expandable<first_elem_t>::value,
+                    "Can't place even 1 sequence element into cell");
+      builder b;
+      if constexpr (is_optional<first_elem_t>::value) {
+        if (first_elem)
+          b = build_chain(std::tuple_cat(std::make_tuple(schema::bool_t(true)), to_std_tuple(*first_elem)));
+        else
+          b.stu(0, 1);
+      } else {
+        b = build_chain(to_std_tuple(std::get<0>(tup)));
+      }
+      if constexpr (sizeof...(Elems) > 1) {
+        auto next_subtup = hana::take_back_c<sizeof...(Elems) - 1>(tup);
+        b.stref(build_chain(next_subtup).make_cell());
+      }
+      return b;
+    } else {
+      auto cur_subtup = hana::take_front_c<fit_count>(tup);
+      builder b = schema::build(cur_subtup);
+      if constexpr (sizeof...(Elems) > fit_count) {
+        auto next_subtup = hana::take_back_c<sizeof...(Elems) - fit_count>(tup);
+        b.stref(build_chain(next_subtup).make_cell());
+      }
+      return b;
+    }
   }
-  return b.make_cell();
 }
 
 template<class Tup, unsigned Offset>
@@ -47,20 +98,53 @@ struct chain_parser_impl {};
 template<class... Elems, unsigned Offset>
 struct chain_parser_impl<std::tuple<Elems...>, Offset> {
   using Tup = std::tuple<Elems...>;
-  static __always_inline Tup parse(parser p) {
-    static constexpr unsigned fit_count =
-      extract_fit<cell::max_bits - Offset, cell::max_refs - 1, 0, Elems...>::value;
-    static_assert(fit_count > 0, "Can't place even 1 sequence element into cell");
-    using FrontT = decltype(hana::take_front_c<fit_count>(Tup{}));
-    auto [front_tup, =p] = schema::parse_continue<FrontT>(p);
-    require(!!front_tup, error_code::custom_data_parse_error);
-    if constexpr (sizeof...(Elems) > fit_count) {
-      using NextT = decltype(hana::take_back_c<sizeof...(Elems) - fit_count>(Tup{}));
-      parser next_p(p.ldrefrtos());
-      auto next_tup = chain_parser_impl<NextT, 0>::parse(next_p);
-      return std::tuple_cat(*front_tup, next_tup);
+  static __always_inline std::pair<Tup, parser> parse(parser p) {
+    if constexpr (sizeof...(Elems) == 0) {
+      return { Tup{}, p };
     } else {
-      return *front_tup;
+      static constexpr unsigned fit_count =
+        extract_fit<cell::max_bits - Offset, cell::max_refs - 1, 0, Elems...>::value;
+      if constexpr (fit_count == 0) {
+        // expanding first element
+        using first_elem_t = typename std::tuple_element<0, Tup>::type;
+        static_assert(is_expandable<first_elem_t>::value,
+                      "Can't place even 1 sequence element into cell");
+        first_elem_t elem;
+        if constexpr (is_optional<first_elem_t>::value) {
+          if (p.ldu(1)) {
+            using SubElem = typename std::decay<decltype(*elem)>::type;
+            using ExpandedTup = typename to_std_tuple_t<SubElem>;
+            auto [elem_tup, =p] = chain_parser_impl<ExpandedTup, 1>::parse(p);
+            elem = to_struct<SubElem>(elem_tup);
+          } else {
+            elem = {};
+          }
+        } else {
+          using ExpandedTup = typename to_std_tuple_t<first_elem_t>::type;
+          auto [elem_tup, =p] = chain_parser_impl<ExpandedTup, Offset>::parse(p);
+          elem = to_struct<first_elem_t>(elem_tup);
+        }
+        if constexpr (sizeof...(Elems) > 1) {
+          using NextT = decltype(hana::take_back_c<sizeof...(Elems) - 1>(Tup{}));
+          parser next_p(p.ldrefrtos());
+          auto [next_tup, =next_p] = chain_parser_impl<NextT, 0>::parse(next_p);
+          return { std::tuple_cat(std::make_tuple(elem), next_tup), p };
+        } else {
+          return { std::make_tuple(elem), p };
+        }
+      } else {
+        using FrontT = decltype(hana::take_front_c<fit_count>(Tup{}));
+        auto [front_tup, =p] = schema::parse_continue<FrontT>(p);
+        require(!!front_tup, error_code::custom_data_parse_error);
+        if constexpr (sizeof...(Elems) > fit_count) {
+          using NextT = decltype(hana::take_back_c<sizeof...(Elems) - fit_count>(Tup{}));
+          parser next_p(p.ldrefrtos());
+          auto [next_tup, =next_p] = chain_parser_impl<NextT, 0>::parse(next_p);
+          return { std::tuple_cat(*front_tup, next_tup), p };
+        } else {
+          return { *front_tup, p };
+        }
+      }
     }
   }
 };
@@ -68,8 +152,80 @@ struct chain_parser_impl<std::tuple<Elems...>, Offset> {
 template<class Data, unsigned Offset>
 static __always_inline Data parse_chain(parser p) {
   using Tup = to_std_tuple_t<Data>;
-  auto rv_tup = chain_parser_impl<Tup, Offset>::parse(p);
+  auto [rv_tup, =p] = chain_parser_impl<Tup, Offset>::parse(p);
   return to_struct<Data>(rv_tup);
+}
+
+// If element with such estimation Est is for sure parsable ({bits, refs} >= estimation max)
+template<class Est>
+__always_inline bool check_sure_parsable(unsigned bits, unsigned refs) {
+  // If estimated element is more than cell size
+  if constexpr (Est::max_bits > cell::max_bits)
+    return false;
+  if constexpr (Est::max_refs >= cell::max_refs)
+    return false;
+  if (bits < Est::max_bits)
+    return false;
+  if constexpr (Est::max_refs)
+    if (refs <= Est::max_refs) // '<=' because we need to reserve additional ref for chaining
+      return false;
+  return true;
+}
+
+// If element with such estimation Est is for sure not parsable ({bits, refs} < estimation min)
+template<class Est>
+__always_inline bool check_sure_unparsable(unsigned bits, unsigned refs) {
+  if (bits < Est::min_bits)
+    return true;
+  if constexpr (Est::min_refs)
+    if (refs <= Est::min_refs) // '<=' because we need to reserve additional ref for chaining
+      return true;
+  return false;
+}
+
+template<class Tup>
+struct dyn_chain_parser_impl {};
+template<class... Elems>
+struct dyn_chain_parser_impl<std::tuple<Elems...>> {
+  using Tup = std::tuple<Elems...>;
+  static __always_inline std::pair<Tup, parser> parse(parser p, unsigned bits, unsigned refs) {
+    if constexpr (sizeof...(Elems) == 0) {
+      return { Tup{}, p };
+    } else {
+      // All elements may be parsed without additional checks
+      using est_t = schema::estimate_element<Tup>;
+      if (check_sure_parsable<est_t>(bits, refs)) {
+        auto [full_tup, =p] = schema::parse_continue<Tup>(p);
+        return { *full_tup, p };
+      } else {
+        using PrevT = decltype(hana::take_front_c<sizeof...(Elems) - 1>(Tup{}));
+        auto [prev_tup, =p] = dyn_chain_parser_impl<PrevT>::parse(p, bits, refs);
+        using last_elem_t = typename std::tuple_element<sizeof...(Elems) - 1, Tup>::type;
+        using est_last_t = schema::estimate_element<last_elem_t>;
+        auto [last_bits, last_refs] = p.sl().sbitrefs();
+        if (check_sure_unparsable<est_last_t>(last_bits, last_refs)) {
+          require(last_bits == 0, error_code::non_empty_bits_at_cell_wrap);
+          require(last_refs == 1, error_code::non_single_refs_at_cell_wrap);
+          p = parser(p.ldrefrtos());
+        }
+        auto [last_elem, =p] = schema::parse_continue<last_elem_t>(p);
+        return { std::tuple_cat(prev_tup, std::make_tuple(*last_elem)), p };
+      }
+    }
+  }
+};
+
+template<class Data>
+static Data parse_chain_dynamic(parser p) {
+  using Tup = to_std_tuple_t<Data>;
+  if constexpr (std::tuple_size<Tup>::value == 0) {
+    return Data{};
+  } else {
+    auto [bits, refs] = p.sl().sbitrefs();
+    auto [rv_tup, =p] = dyn_chain_parser_impl<Tup>::parse(p, bits, refs);
+    p.ends();
+    return to_struct<Data>(rv_tup);
+  }
 }
 
 } // namespace tvm

--- a/stdlib/cpp-sdk/tvm/contract_handle.hpp
+++ b/stdlib/cpp-sdk/tvm/contract_handle.hpp
@@ -94,7 +94,9 @@ public:
                              schema::Grams amount, unsigned flags)
     : addr_(addr), init_(init), amount_(amount), flags_(flags) {}
   template<auto Func, class... Args>
-  inline void call(Args... args) const { contract_deploy_impl(addr_, init_, amount_, flags_, args...); }
+  inline void call(Args... args) const {
+    contract_deploy_impl<Interface, Func>(addr_, init_, amount_, flags_, args...);
+  }
 private:
   schema::lazy<schema::MsgAddressInt> addr_;
   schema::StateInit init_;

--- a/stdlib/cpp-sdk/tvm/error_code.hpp
+++ b/stdlib/cpp-sdk/tvm/error_code.hpp
@@ -6,16 +6,16 @@ struct error_code {
   // solidity conformant error codes
   // (https://www.notion.so/tonlabs/306a53e50ea44623a999f2f199fd0f57?v=7f61664dee434e27a65d9c3565b27cb1)
   static constexpr int invalid_signature           = 40;
-
+  static constexpr int wrong_public_call           = 41; // requested method not found
+  static constexpr int bad_incoming_msg            = 48; // invalid inbound message
   // custom error codes
 
   static constexpr int persistent_data_parse_error = 51;
   static constexpr int custom_data_parse_error     = 52;
   static constexpr int bad_tupled_variant_kind     = 53;
   static constexpr int unsupported_call_method     = 54;
-  static constexpr int wrong_public_call           = 55;
+  static constexpr int unsupported_bounced_msg     = 55;
   static constexpr int no_persistent_data          = 56;
-  static constexpr int bad_incoming_msg            = 57;
 
   static constexpr int replay_attack_check         = 59;
   static constexpr int bad_arguments               = 60;
@@ -23,6 +23,10 @@ struct error_code {
   static constexpr int method_called_without_init  = 62;
   static constexpr int iterator_overflow           = 63;
   static constexpr int empty_container             = 64;
+
+  // test/temp error codes
+  static constexpr int non_empty_bits_at_cell_wrap  = 65;
+  static constexpr int non_single_refs_at_cell_wrap = 66;
 };
 
 } // namespace tvm

--- a/stdlib/cpp-sdk/tvm/reflection.hpp
+++ b/stdlib/cpp-sdk/tvm/reflection.hpp
@@ -30,6 +30,12 @@ template<class Interface, unsigned Index>
 using get_interface_method_getter =
   __reflect_method_getter<std::integral_constant, bool, Interface, Index>;
 template<class Interface, unsigned Index>
+using get_interface_method_noaccept =
+  __reflect_method_noaccept<std::integral_constant, bool, Interface, Index>;
+template<class Interface, unsigned Index>
+using get_interface_method_dyn_chain_parse =
+  __reflect_method_dyn_chain_parse<std::integral_constant, bool, Interface, Index>;
+template<class Interface, unsigned Index>
 using get_interface_method_no_read_persistent =
   __reflect_method_no_read_persistent<std::integral_constant, bool, Interface, Index>;
 template<class Interface, unsigned Index>
@@ -39,6 +45,9 @@ template<class Interface, unsigned Index>
 using get_interface_method_rv = __reflect_method_rv<Interface, Index>;
 template<class Interface, unsigned Index>
 using get_interface_method_arg_struct = __reflect_method_arg_struct<Interface, Index>;
+
+template<auto MethodPtr>
+using args_struct_t = __reflect_method_ptr_arg_struct<MethodPtr>;
 
 template<class Fmt>
 using parsed_value = Fmt;

--- a/stdlib/cpp-sdk/tvm/schema/estimate_element.hpp
+++ b/stdlib/cpp-sdk/tvm/schema/estimate_element.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <tvm/schema/basics.hpp>
+#include <tvm/schema/message.hpp>
 
 namespace tvm { namespace schema {
 

--- a/stdlib/cpp-sdk/tvm/schema/get_bitsize.hpp
+++ b/stdlib/cpp-sdk/tvm/schema/get_bitsize.hpp
@@ -38,6 +38,10 @@ template<unsigned _keylen, class _element_type>
 struct get_bitsize<HashmapE<_keylen, _element_type>> {
   static constexpr unsigned value = 0;
 };
+template<class T>
+struct get_bitsize<std::optional<T>> {
+  static constexpr unsigned value = 0;
+};
 
 // Counting refs as dynamic
 template<class _Tp>
@@ -97,6 +101,10 @@ struct get_bitsize<EitherRight<Y>> {
 template<class X, class Y>
 struct get_bitsize<Either<X, Y>> {
   static constexpr unsigned value = get_bitsize< to_std_tuple_t<Either<X, Y>> >::value;
+};
+template<class T>
+struct get_bitsize<lazy<T>> {
+  static constexpr unsigned value = get_bitsize<T>::value;
 };
 
 // Helper template constant


### PR DESCRIPTION
* "noaccept" attribute
* __reflect_method_ptr_arg_struct to request method arguments structure by method ptr
* build_chain improvement to split internal expandable objects
* contract_handle::deploy_call
* _on_bounced method support for contract
* load_persistent_data / save_persistent_data as separate functions
* parse_chain_dynamic for correct arguments parsing (with cell wrapping)