### PR TITLE
Fix -c -emit-llvm handling in driver

### DIFF
--- a/llvm/tools/clang/lib/Driver/Driver.cpp
+++ b/llvm/tools/clang/lib/Driver/Driver.cpp
@@ -2938,7 +2938,8 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
   phases::ID FinalPhase = getFinalPhase(Args, &FinalPhaseArg);
 
   // TVM local change begin
-  if (getTargetTriple() == "tvm" && FinalPhase == phases::Assemble) {
+  if (getTargetTriple() == "tvm" && FinalPhase == phases::Assemble
+      && !Args.hasArg(options::OPT_emit_llvm)) {
     Diag(clang::diag::warn_tvm_unsupported_assembler);
     FinalPhase = phases::Link;
     FinalPhaseArg = nullptr;

--- a/llvm/tools/clang/test/Driver/tvm-pipeline.cpp
+++ b/llvm/tools/clang/test/Driver/tvm-pipeline.cpp
@@ -3,3 +3,7 @@
 // CHECK: warning: TVM doesn't support assembler; -c flag ignored
 // CHECK: clang
 // CHECK-NEXT: tvm_linker
+
+// RUN: %clang -target tvm -c -emit-llvm -### %s 2>&1 \
+// RUN:   | FileCheck %s -check-prefix=EMITLLVM
+// EMITLLVM-NOT: warning: TVM doesn't support assembler; -c flag ignored


### PR DESCRIPTION
-c -emit-llvm is the only valid case of using "assembler" for TVM.