### PR TITLE
Make TVM the default target in CMake cache file

### DIFF
--- a/cmake/Cache/ton-compiler.cmake
+++ b/cmake/Cache/ton-compiler.cmake
@@ -3,12 +3,14 @@ set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "")
 # TON-Compiler specific options
 set(LLVM_EXPERIMENTAL_TARGETS_TO_BUILD   "TVM"         CACHE STRING "")
 set(LLVM_TARGETS_TO_BUILD                ""            CACHE STRING "")
+set(LLVM_DEFAULT_TARGET_TRIPLE           "tvm"         CACHE STRING "")
 set(LLVM_BYTE_SIZE_IN_BITS               257           CACHE STRING "")
 
 set(CLANG_VENDOR                         "TON Labs"    CACHE STRING "")
 
 set(LLVM_INSTALL_TOOLCHAIN_ONLY          ON            CACHE BOOL "")
 set(CLANG_ENABLE_ARCMT                   OFF           CACHE BOOL "")
+set(CLANG_ENABLE_STATIC_ANALYZER         OFF           CACHE BOOL "")
 set(BUG_REPORT_URL
   "https://github.com/tonlabs/TON-Compiler/issues"
   CACHE STRING "")

--- a/llvm/tools/clang/lib/Driver/Driver.cpp
+++ b/llvm/tools/clang/lib/Driver/Driver.cpp
@@ -1439,16 +1439,22 @@ void Driver::PrintVersion(const Compilation &C, raw_ostream &OS) const {
   // know what the client would like to do.
   OS << getClangFullVersion() << '\n';
   const ToolChain &TC = C.getDefaultToolChain();
-  OS << "Target: " << TC.getTripleString() << '\n';
+  // TVM local begin
+  // Don't display target and the thread model if the compiler is built
+  // with cmake/Cache/ton-compiler.cmake
+  if (TC.getTripleString() != "tvm") {
+    OS << "Target: " << TC.getTripleString() << '\n';
 
-  // Print the threading model.
-  if (Arg *A = C.getArgs().getLastArg(options::OPT_mthread_model)) {
-    // Don't print if the ToolChain would have barfed on it already
-    if (TC.isThreadModelSupported(A->getValue()))
-      OS << "Thread model: " << A->getValue();
-  } else
-    OS << "Thread model: " << TC.getThreadModel();
-  OS << '\n';
+    // Print the threading model.
+    if (Arg *A = C.getArgs().getLastArg(options::OPT_mthread_model)) {
+      // Don't print if the ToolChain would have barfed on it already
+      if (TC.isThreadModelSupported(A->getValue()))
+        OS << "Thread model: " << A->getValue();
+    } else
+      OS << "Thread model: " << TC.getThreadModel();
+    OS << '\n';
+  }
+  // TVM local end
 
   // Print out the install directory.
   OS << "InstalledDir: " << InstalledDir << '\n';


### PR DESCRIPTION
If the compiler is built using cmake/Cache/ton-compiler.cmake, tvm is
going to be the default target.
Aside from that the patch removes information about the target and
theread model if the target is tvm.