### PR TITLE
Pretify driver

### DIFF
--- a/cmake/Cache/ton-compiler.cmake
+++ b/cmake/Cache/ton-compiler.cmake
@@ -3,7 +3,9 @@ set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "")
 # TON-Compiler specific options
 set(LLVM_EXPERIMENTAL_TARGETS_TO_BUILD   "TVM"         CACHE STRING "")
 set(LLVM_TARGETS_TO_BUILD                ""            CACHE STRING "")
-set(LLVM_DEFAULT_TARGET_TRIPLE           "tvm"         CACHE STRING "")
+set(LLVM_DEFAULT_TARGET_TRIPLE
+  "tvm-unknown-unknown"
+  CACHE STRING "")
 set(LLVM_BYTE_SIZE_IN_BITS               257           CACHE STRING "")
 
 set(CLANG_VENDOR                         "TON Labs"    CACHE STRING "")
@@ -14,6 +16,9 @@ set(CLANG_ENABLE_STATIC_ANALYZER         OFF           CACHE BOOL "")
 set(BUG_REPORT_URL
   "https://github.com/tonlabs/TON-Compiler/issues"
   CACHE STRING "")
+set(DEFAULT_SYSROOT
+    ${CMAKE_INSTALL_PREFIX}
+    CACHE PATH "")
 
 set(LLVM_TOOLCHAIN_TOOLS
   llvm-link

--- a/llvm/tools/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/llvm/tools/clang/lib/Driver/ToolChains/Clang.cpp
@@ -3770,6 +3770,9 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     } else {
       A->render(Args, CmdArgs);
     }
+  // TVM local begin
+  } else if (Triple.isTVM())  {
+    CmdArgs.push_back("-O3");
   }
 
   // Warn about ignored options to clang.

--- a/llvm/tools/clang/lib/Driver/ToolChains/TVM.h
+++ b/llvm/tools/clang/lib/Driver/ToolChains/TVM.h
@@ -28,6 +28,7 @@ public:
                     const InputInfo &Output, const InputInfoList &Inputs,
                     const llvm::opt::ArgList &TCArgs,
                     const char *LinkingOutput) const override;
+
 private:
   /// \return llvm-link output file name.
   const char *constructLLVMLinkCommand(Compilation &C, const JobAction &JA,
@@ -35,12 +36,19 @@ private:
                                        const llvm::opt::ArgList &Args,
                                        llvm::StringRef OutputFilePrefix) const;
 
+  /// \return abi-json output file name.
+  const char *constructClangCommand(Compilation &C, const JobAction &JA,
+                                    const InputInfoList &Inputs,
+                                    const llvm::opt::ArgList &Args,
+                                    llvm::StringRef OutputFilePrefix,
+                                    const char *InputFileName) const;
   /// \return opt output file name.
   const char *constructOptCommand(Compilation &C, const JobAction &JA,
                                   const InputInfoList &Inputs,
                                   const llvm::opt::ArgList &Args,
                                   llvm::StringRef OutputFilePrefix,
-                                  const char *InputFileName, bool Internalize) const;
+                                  const char *InputFileName,
+                                  bool Internalize) const;
 
   /// \return llc output file name.
   const char *constructLlcCommand(Compilation &C, const JobAction &JA,
@@ -58,7 +66,7 @@ namespace toolchains {
 class LLVM_LIBRARY_VISIBILITY TVM final : public ToolChain {
 public:
   TVM(const Driver &D, const llvm::Triple &Triple,
-              const llvm::opt::ArgList &Args);
+      const llvm::opt::ArgList &Args);
 
 private:
   bool IsMathErrnoDefault() const override;

--- a/llvm/tools/clang/test/CodeGen/tvm/string-literal.c
+++ b/llvm/tools/clang/test/CodeGen/tvm/string-literal.c
@@ -4,5 +4,5 @@
 // CHECK: @.str = private unnamed_addr constant [4 x i257] [i257 98, i257 97, i257 114, i257 0], align 1
 char foo(int n) { return "bar"[n]; }
 
-// CHECK: @str = dso_local global [8 x i257] [i257 115, i257 116, i257 114, i257 0, i257 0, i257 0, i257 0, i257 0], align 1
+// CHECK: @str = dso_local local_unnamed_addr global [8 x i257] [i257 115, i257 116, i257 114, i257 0, i257 0, i257 0, i257 0, i257 0], align 1
 char str[8] = "str";

--- a/llvm/tools/clang/test/Driver/tvm-pipeline.cpp
+++ b/llvm/tools/clang/test/Driver/tvm-pipeline.cpp
@@ -3,6 +3,7 @@
 // CHECK: warning: TVM doesn't support assembler; -c flag ignored
 // CHECK: clang
 // CHECK: llvm-link
+// CHECK: clang
 // CHECK: opt
 // CHECK: opt
 // CHECK: llc
@@ -12,6 +13,7 @@
 // RUN:   | FileCheck %s -check-prefix=CHECKO
 // CHECKO: clang
 // CHECKO: llvm-link
+// CHECKO: clang
 // CHECKO: opt
 // CHECKO: opt
 // CHECKO: llc


### PR DESCRIPTION
* Make O3 default optimization level for TVM.
* Make default sysroot equal to install prefix (but the full path has to be
specified to utilize that feature).
* Enclose clang invocation to generate the abi into the pipeline.
* Make linker to generate what is specified in `-o` option.

Notes:
1. Clang invocation is a hacky way to generate the abi, it's probably
better to move it in llc.
2. The name for json file is <output stem>.json (a.json by default),
it changes if to specify `-o` option, but the tvc itself is named as the
linker decide to name it. A linker fix is coming soon.
3. Require 3211ca7041f2452e2e7c4e8080ce311ca80e2ebc commit in linker.