### PR TITLE
Remote contract call proxy

### DIFF
--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/contract_handle.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/contract_handle.hpp
@@ -17,12 +17,10 @@ using good_call_args_t = decltype( (((Interface*)nullptr)->*(Func::value))(Args{
 template<class Interface, auto Func, class... Args>
 constexpr bool good_call_args_v = std::experimental::is_detected_v<good_call_args_t, Interface, proxy_method<Func>, Args...>;
 
-template<class Interface, auto Func, class... Args>
+template<auto Func, class... Args>
 __always_inline
 void contract_call_impl(schema::lazy<schema::MsgAddressInt> addr, schema::Grams amount,
                         unsigned flags, Args... args) {
-  static_assert(good_call_args_v<Interface, Func, Args...>, "Wrong contract handle call arguments");
-
   using namespace schema;
 
   abiv1::internal_msg_header hdr{ uint32(id_v<Func>) };
@@ -93,23 +91,37 @@ struct wait_call_result {
   }
 };
 
-template<class Interface>
+template<auto Func>
+struct get_func_rv {};
+template<typename Cl, typename RetT, typename... Args, RetT (Cl::*Func)(Args...)>
+struct get_func_rv<Func> {
+  using type = RetT;
+};
+template<auto Func>
+using get_func_rv_t = typename get_func_rv<Func>::type;
+
+template<typename RetT>
+using awaitable_ret_t = std::conditional_t<std::is_void_v<RetT>, void, wait_call_result<RetT>>;
+
 class contract_call_configured {
 public:
   contract_call_configured(schema::lazy<schema::MsgAddressInt> addr, schema::Grams amount, unsigned flags)
     : addr_(addr), amount_(amount), flags_(flags) {}
   template<auto Func, class... Args>
   __always_inline void call(Args... args) const {
-    contract_call_impl<Interface, Func>(addr_, amount_, flags_, args...);
+    contract_call_impl<Func>(addr_, amount_, flags_, args...);
   }
   template<auto Func, class... Args>
-  __always_inline wait_call_result<std::invoke_result_t<decltype(Func), Interface, Args...>> call_await(Args... args) const {
-    contract_call_impl<Interface, Func>(addr_, amount_, flags_, args...);
-    temporary_data::setglob(2, __builtin_tvm_cast_from_slice(addr_.sl()));
-    return {};
+  __always_inline
+  awaitable_ret_t<get_func_rv_t<Func>> _call_impl(Args... args) const {
+    contract_call_impl<Func>(addr_, amount_, flags_, args...);
+    if constexpr (!std::is_void_v<get_func_rv_t<Func>>) {
+      temporary_data::setglob(2, __builtin_tvm_cast_from_slice(addr_.sl()));
+      return {};
+    }
   }
 private:
-  mutable schema::lazy<schema::MsgAddressInt> addr_;
+  schema::lazy<schema::MsgAddressInt> addr_;
   schema::Grams amount_;
   unsigned flags_;
 };
@@ -134,12 +146,14 @@ private:
 template<class Interface>
 class contract_handle {
 public:
+  using proxy = __reflect_proxy<Interface, contract_call_configured>;
+
   explicit contract_handle(schema::lazy<schema::MsgAddressInt> addr) : addr_(addr) {}
 
   template<auto Func, class... Args>
   __always_inline
   void call(schema::Grams amount, Args... args) {
-    contract_call_impl<Interface, Func>(addr_, amount, DEFAULT_MSG_FLAGS, args...);
+    contract_call_impl<Func>(addr_, amount, DEFAULT_MSG_FLAGS, args...);
   }
 
   template<auto Func, class... Args>
@@ -149,22 +163,29 @@ public:
   }
 
   __always_inline
-  contract_call_configured<Interface> operator()(
+  contract_call_configured cfg(
       schema::Grams amount = 10000000, unsigned flags = DEFAULT_MSG_FLAGS) const {
-    return contract_call_configured<Interface>(addr_, amount, flags);
+    return contract_call_configured(addr_, amount, flags);
   }
   __always_inline
   contract_deploy_configured<Interface> deploy(
       schema::StateInit init, schema::Grams amount, unsigned flags = DEFAULT_MSG_FLAGS) const {
     return contract_deploy_configured<Interface>(addr_, init, amount, flags);
   }
+
+  proxy operator()(schema::Grams amount = 10000000, unsigned flags = DEFAULT_MSG_FLAGS) const {
+    return proxy(addr_, amount, flags);
+  }
 private:
   schema::lazy<schema::MsgAddressInt> addr_;
 };
 
+template<class Interface>
+using handle = contract_handle<Interface>;
+
 /*
 void example_usage(contract_handle<Interface> handle) {
-  handle(10, SENDER_WANTS_TO_PAY_FEES_SEPARATELY).call<&Interface::method>(arg0, arg1, ...);
+  handle(Grams(10), SENDER_WANTS_TO_PAY_FEES_SEPARATELY).method(arg0, arg1, ...);
   handle.deploy(init, 10, SENDER_WANTS_TO_PAY_FEES_SEPARATELY).call<&Interface::method>(arg0, arg1, ...);
 }
 */

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/dictionary.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/dictionary.hpp
@@ -193,7 +193,11 @@ struct ElementRef {
       ++size_;
     return *this;
   }
-  operator bool() const { return !!static_cast<Element>(*this); }
+  __always_inline operator Element() const {
+    auto [sl, succ] = dict_.dictuget(idx_, KeyLen);
+    require(succ, error_code::iterator_overflow);
+    return schema::parse<Element>(sl);
+  }
 
   __always_inline void swap(ElementRef v) const {
     auto [sl1, succ1] = dict_.dictuget(idx_, KeyLen);
@@ -207,7 +211,14 @@ struct ElementRef {
   schema::uint32& size_;
   unsigned idx_;
 };
-  
+template<class Element, unsigned KeyLen>
+void swap(ElementRef<Element, KeyLen>& ref1, ElementRef<Element, KeyLen>& ref2) {
+  auto v1 = static_cast<Element>(ref1);
+  auto v2 = static_cast<Element>(ref2);
+  ref1 = v2;
+  ref2 = v1;
+}
+
 template<class Element, unsigned KeyLen>
 struct dictionary_array_iterator : boost::operators<dictionary_array_iterator<Element, KeyLen>> {
   using iterator_category = std::random_access_iterator_tag;

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/resumable.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/resumable.hpp
@@ -68,7 +68,7 @@ public:
   __always_inline
   ~resumable() { handle_.destroy(); }
 
-  template<std::enable_if_t<!std::is_void_v<T>, int> = 0>
+  template<class T1 = T, std::enable_if_t<!std::is_void_v<T1>, int> = 0>
   __always_inline
   T return_val() const {
     return handle_.promise().val_;

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/schema/basics.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/schema/basics.hpp
@@ -618,6 +618,25 @@ struct Either {
   bool operator == (const Either& v) const {
     return val_ == v.val_;
   }
+  template<class T>
+  __always_inline bool isa() const {
+    if constexpr (std::is_same_v<T, X>)
+      return std::holds_alternative<EitherLeft<X>>(val_);
+    else if constexpr (std::is_same_v<T, Y>)
+      return std::holds_alternative<EitherRight<Y>>(val_);
+    else
+      return false;
+  }
+  template<class T>
+  __always_inline T get() const {
+    if constexpr (std::is_same_v<T, X>)
+      return std::get<EitherLeft<X>>(val_).val;
+    else if constexpr (std::is_same_v<T, Y>)
+      return std::get<EitherRight<Y>>(val_).val;
+    else
+      static_assert(std::is_same_v<T, X> || std::is_same_v<T, Y>,
+                    "bad get in Either variant");
+  }
   base_t operator()() const { return val_; }
   base_t val_;
 };

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/schema/basics.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/schema/basics.hpp
@@ -140,6 +140,11 @@ template<unsigned _left_len, unsigned _right_len>
 auto operator*(int_t<_left_len> l, int_t<_right_len> r) {
   return int_t<std::max(_left_len, _right_len)>(l.val_ * r.val_);
 }
+auto operator*(int_t<8> l, int_t<8> r) { return int_t<8>{l.val_ * r.val_}; }
+auto operator*(int_t<16> l, int_t<16> r) { return int_t<16>{l.val_ * r.val_}; }
+auto operator*(int_t<32> l, int_t<32> r) { return int_t<32>{l.val_ * r.val_}; }
+auto operator*(int_t<64> l, int_t<64> r) { return int_t<64>{l.val_ * r.val_}; }
+auto operator*(int_t<128> l, int_t<128> r) { return int_t<128>{l.val_ * r.val_}; }
 template<unsigned _len>
 auto operator*(int_t<_len> l, unsigned r) {
   return int_t<_len>(l.val_ * r);
@@ -681,6 +686,9 @@ struct lazy {
   __always_inline lazy(_Tp val);           // implemented in make_builder.hpp
   __always_inline void operator=(_Tp val); // implemented in make_builder.hpp
   __always_inline void operator=(slice sl) { sl_ = sl; }
+
+  __always_inline
+  static lazy make_std(int8 workchain, uint256 addr); // implemented in make_builder.hpp
 
   DEFAULT_EQUAL(lazy<_Tp>)
   slice sl_;

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/schema/make_builder.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/schema/make_builder.hpp
@@ -5,6 +5,7 @@
 #include <tvm/schema/builder/struct_builder.hpp>
 #include <tvm/schema/builder/variant_builder.hpp>
 #include <tvm/schema/builder/dynamic_field_builder.hpp>
+#include <tvm/schema/message.hpp>
 
 namespace tvm { namespace schema {
 
@@ -169,6 +170,13 @@ __always_inline lazy<_Tp>::lazy(_Tp val) {
 template<typename _Tp>
 __always_inline void lazy<_Tp>::operator=(_Tp val) {
   sl_ = build(val).make_slice();
+}
+
+template<typename _Tp>
+__always_inline
+lazy<_Tp> lazy<_Tp>::make_std(int8 workchain, uint256 addr) {
+  lazy<_Tp> rv{ MsgAddressInt{ addr_std{ {}, {}, int8{workchain}, addr } } };
+  return rv;
 }
 
 }} // namespace tvm::schema

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/schema/make_parser.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/schema/make_parser.hpp
@@ -117,9 +117,9 @@ struct make_parser_impl<ref<_Tp>> {
   inline static std::tuple<optional<value_type>, parser, _Ctx> parse(parser p, _Ctx ctx) {
     auto inner_slice = p.ldrefrtos();
     parser inner_parser(inner_slice);
-    auto [rv, new_p, new_ctx] = make_parser_impl<_Tp>::parse(inner_parser, ctx);
+    auto [rv, =inner_parser, new_ctx] = make_parser_impl<_Tp>::parse(inner_parser, ctx);
     inner_parser.ends();
-    return std::tuple(rv, new_p, new_ctx);
+    return std::tuple(value_type{*rv}, p, new_ctx);
   }
 };
 template<>
@@ -137,8 +137,7 @@ struct make_parser_impl<anyval> {
   using value_type = anyval;
   template<class _Ctx>
   inline static std::tuple<optional<value_type>, parser, _Ctx> parse(parser p, _Ctx ctx) {
-    // TODO: implement PUSHSLICE for empty slices instead of "builder().make_slice()"
-    return std::tuple(anyval{p.get_cur_slice()}, builder().make_slice(), ctx);
+    return { anyval{p.get_cur_slice()}, parser(slice::create_empty()), ctx };
   }
 };
 

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/schema/parser/variant_parser.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/schema/parser/variant_parser.hpp
@@ -38,4 +38,21 @@ struct make_parser_impl<std::variant<Types...>> {
   }
 };
 
+template<class X, class Y>
+struct make_parser_impl<Either<X, Y>> {
+  using value_type = Either<X, Y>;
+  using base_t = typename value_type::base_t;
+
+  template<class _Ctx>
+  inline static std::tuple<optional<value_type>, parser, _Ctx> parse(parser p, _Ctx ctx) {
+    auto [opt_rv, new_p, new_ctx] = make_parser_impl<base_t>::parse(p, ctx);
+    if (opt_rv) {
+      value_type rv;
+      rv.val_ = *opt_rv;
+      return { rv, new_p, new_ctx };
+    }
+    return { {}, p, ctx };
+  }
+};
+
 }} // namespace tvm::schema

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/smart_switcher.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/smart_switcher.hpp
@@ -429,7 +429,8 @@ struct smart_switcher_impl {
               if constexpr (supports_set_persistent_data_header_v<Contract>)
                 c.set_persistent_data_header(persistent_data_header);
             } else {
-              send_answer<Internal>(c, in_hdr->function_id(), rv.return_val());
+              if constexpr (!std::is_same_v<rv_t, resumable<void>>)
+                send_answer<Internal>(c, in_hdr->function_id(), rv.return_val());
             }
           } else {
             send_answer<Internal>(c, in_hdr->function_id(), rv);
@@ -454,7 +455,8 @@ struct smart_switcher_impl {
               if constexpr (supports_set_persistent_data_header_v<Contract>)
                 c.set_persistent_data_header(persistent_data_header);
             } else {
-              send_answer<Internal>(c, in_hdr->function_id(), rv.return_val());
+              if constexpr (!std::is_same_v<rv_t, resumable<void>>)
+                send_answer<Internal>(c, in_hdr->function_id(), rv.return_val());
             }
           } else {
             send_answer<Internal>(c, in_hdr->function_id(), rv);
@@ -589,8 +591,10 @@ struct smart_process_answer_impl {
           if constexpr (supports_set_persistent_data_header_v<Contract>)
             c.set_persistent_data_header(persistent_data_header);
         } else {
-          // coroutine is done, sending an answer
-          send_answer<is_internal>(c, my_method_id, res.return_val());
+          if constexpr (!std::is_same_v<rv_t, resumable<void>>) {
+            // coroutine is done, sending an answer
+            send_answer<is_internal>(c, my_method_id, res.return_val());
+          }
         }
         // Store persistent data
         auto &base = static_cast<DContract&>(c);

--- a/llvm/tools/clang/include/clang/AST/ASTContext.h
+++ b/llvm/tools/clang/include/clang/AST/ASTContext.h
@@ -368,6 +368,8 @@ class ASTContext : public RefCountedBase<ASTContext> {
   mutable IdentifierInfo *ReflectMethodPtrArgStructName = nullptr;
   /// The identifier '__reflect_smart_interface'.
   mutable IdentifierInfo *ReflectSmartInterfaceName = nullptr;
+  /// The identifier '__reflect_proxy'.
+  mutable IdentifierInfo *ReflectProxyName = nullptr;
   /// The identifier '__reflect_method_ptr'.
   mutable IdentifierInfo *ReflectMethodPtrName = nullptr;
   // TVM local end
@@ -569,6 +571,7 @@ private:
   mutable BuiltinTemplateDecl *ReflectMethodArgStructDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodPtrArgStructDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectSmartInterfaceDecl = nullptr;
+  mutable BuiltinTemplateDecl *ReflectProxyDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodPtrDecl = nullptr;
   // TVM local end
 
@@ -1091,6 +1094,7 @@ public:
   BuiltinTemplateDecl *getReflectMethodArgStructDecl() const;
   BuiltinTemplateDecl *getReflectMethodPtrArgStructDecl() const;
   BuiltinTemplateDecl *getReflectSmartInterfaceDecl() const;
+  BuiltinTemplateDecl *getReflectProxyDecl() const;
   BuiltinTemplateDecl *getReflectMethodPtrDecl() const;
   // TVM local end
 
@@ -1952,6 +1956,12 @@ public:
     if (!ReflectSmartInterfaceName)
       ReflectSmartInterfaceName = &Idents.get("__reflect_smart_interface");
     return ReflectSmartInterfaceName;
+  }
+
+  IdentifierInfo *getReflectProxyName() const {
+    if (!ReflectProxyName)
+      ReflectProxyName = &Idents.get("__reflect_proxy");
+    return ReflectProxyName;
   }
 
   IdentifierInfo *getReflectMethodPtrName() const {

--- a/llvm/tools/clang/include/clang/Basic/Builtins.h
+++ b/llvm/tools/clang/include/clang/Basic/Builtins.h
@@ -299,6 +299,9 @@ enum BuiltinTemplateKind : int {
   /// This names the __reflect_smart_interface BuiltinTemplateDecl.
   BTK__reflect_smart_interface,
 
+  /// This names the __reflect_proxy BuiltinTemplateDecl.
+  BTK__reflect_proxy,
+
   /// This names the __reflect_method_ptr BuiltinTemplateDecl.
   BTK__reflect_method_ptr
   // TVM local end

--- a/llvm/tools/clang/lib/AST/ASTContext.cpp
+++ b/llvm/tools/clang/lib/AST/ASTContext.cpp
@@ -1182,6 +1182,14 @@ ASTContext::getReflectSmartInterfaceDecl() const {
 }
 
 BuiltinTemplateDecl *
+ASTContext::getReflectProxyDecl() const {
+  if (!ReflectProxyDecl)
+    ReflectProxyDecl = buildBuiltinTemplateDecl(
+        BTK__reflect_proxy, getReflectProxyName());
+  return ReflectProxyDecl;
+}
+
+BuiltinTemplateDecl *
 ASTContext::getReflectMethodPtrDecl() const {
   if (!ReflectMethodPtrDecl)
     ReflectMethodPtrDecl = buildBuiltinTemplateDecl(

--- a/llvm/tools/clang/lib/AST/DeclTemplate.cpp
+++ b/llvm/tools/clang/lib/AST/DeclTemplate.cpp
@@ -1626,6 +1626,28 @@ createReflectSmartInterfaceParameterList(const ASTContext &C, DeclContext *DC) {
                                        SourceLocation(), nullptr);
 }
 
+// __reflect_proxy<Interface, Impl> - Proxy class for Interface
+static TemplateParameterList *
+createReflectProxyParameterList(const ASTContext &C, DeclContext *DC) {
+
+  // typename Interface
+  auto *Interface = TemplateTypeParmDecl::Create(
+      C, DC, SourceLocation(), SourceLocation(), /*Depth=*/0, /*Position=*/0,
+      /*Id=*/nullptr, /*Typename=*/true, /*ParameterPack=*/false);
+  Interface->setImplicit(true);
+
+  // typename Impl
+  auto *Impl = TemplateTypeParmDecl::Create(
+      C, DC, SourceLocation(), SourceLocation(), /*Depth=*/0, /*Position=*/1,
+      /*Id=*/nullptr, /*Typename=*/true, /*ParameterPack=*/false);
+  Impl->setImplicit(true);
+
+  NamedDecl *Params[] = { Interface, Impl };
+  return TemplateParameterList::Create(C, SourceLocation(), SourceLocation(),
+                                       llvm::makeArrayRef(Params),
+                                       SourceLocation(), nullptr);
+}
+
 // __reflect_method_ptr<Proxy, Contract, Interface, Index> -
 //   Proxy<&Contract::Method> for method number #Index from Interface
 static TemplateParameterList *
@@ -1719,6 +1741,8 @@ static TemplateParameterList *createBuiltinTemplateParameterList(
     return createReflectMethodPtrArgStructParameterList(C, DC);
   case BTK__reflect_smart_interface:
     return createReflectSmartInterfaceParameterList(C, DC);
+  case BTK__reflect_proxy:
+    return createReflectProxyParameterList(C, DC);
   case BTK__reflect_method_ptr:
     return createReflectMethodPtrParameterList(C, DC);
   // TVM local end

--- a/llvm/tools/clang/lib/Driver/ToolChains/TVM.cpp
+++ b/llvm/tools/clang/lib/Driver/ToolChains/TVM.cpp
@@ -255,9 +255,11 @@ void TVM::AddClangSystemIncludeArgs(const ArgList &DriverArgs,
                                     ArgStringList &CC1Args) const {
   if (!DriverArgs.hasArg(options::OPT_nostdinc)) {
     // Sysroot based include paths.
-    addSystemInclude(DriverArgs, CC1Args, getDriver().SysRoot + "/include/");
-    // Include paths for tests.
-    addSystemInclude(DriverArgs, CC1Args, getDriver().SysRoot);
+    if (!getDriver().SysRoot.empty()) {
+      addSystemInclude(DriverArgs, CC1Args, getDriver().SysRoot + "/include/");
+      // Include paths for tests.
+      addSystemInclude(DriverArgs, CC1Args, getDriver().SysRoot);
+    }
     // Distribution include paths.
     llvm::SmallString<256> Root(tvmRoot());
     llvm::sys::path::append(Root, "include");

--- a/llvm/tools/clang/lib/Sema/SemaLookup.cpp
+++ b/llvm/tools/clang/lib/Sema/SemaLookup.cpp
@@ -740,6 +740,9 @@ static bool LookupBuiltin(Sema &S, LookupResult &R) {
         } else if (II == S.getASTContext().getReflectSmartInterfaceName()) {
           R.addDecl(S.getASTContext().getReflectSmartInterfaceDecl());
           return true;
+        } else if (II == S.getASTContext().getReflectProxyName()) {
+          R.addDecl(S.getASTContext().getReflectProxyDecl());
+          return true;
         } else if (II == S.getASTContext().getReflectMethodPtrName()) {
           R.addDecl(S.getASTContext().getReflectMethodPtrDecl());
           return true;

--- a/llvm/tools/clang/lib/Sema/SemaTemplate.cpp
+++ b/llvm/tools/clang/lib/Sema/SemaTemplate.cpp
@@ -2948,6 +2948,31 @@ processFlagAttribute(Sema &SemaRef,
   return SemaRef.CheckTemplateIdType(Converted[0].getAsTemplate(),
                                      TemplateLoc, SyntheticTemplateArgs);
 }
+
+static ExprResult buildMemberCall(Sema &S, Expr *Base, SourceLocation Loc,
+                                  StringRef Name, MultiExprArg Args,
+                                  const TemplateArgumentListInfo *TemplateArgs) {
+  DeclarationNameInfo NameInfo(&S.PP.getIdentifierTable().get(Name), Loc);
+
+  CXXScopeSpec SS;
+  ExprResult Result = S.BuildMemberReferenceExpr(
+      Base, Base->getType(), Loc, /*IsPtr=*/true, SS,
+      SourceLocation(), nullptr, NameInfo, TemplateArgs,
+      /*Scope=*/nullptr);
+  if (Result.isInvalid())
+    return ExprError();
+
+  // We meant exactly what we asked for. No need for typo correction.
+  if (auto *TE = dyn_cast<TypoExpr>(Result.get())) {
+    S.clearDelayedTypo(TE);
+    S.Diag(Loc, diag::err_no_member)
+        << NameInfo.getName() << Base->getType()->getAsCXXRecordDecl()
+        << Base->getSourceRange();
+    return ExprError();
+  }
+
+  return S.ActOnCallExpr(nullptr, Result.get(), Loc, Args, Loc, nullptr);
+}
 // TVM local end
 
 static QualType
@@ -3377,6 +3402,145 @@ checkBuiltinTemplateIdType(Sema &SemaRef, BuiltinTemplateDecl *BTD,
     Typedef->setAccess(AS_public);
     NewRec->addDecl(Typedef);
 
+    NewRec->completeDefinition();
+    return Context.getRecordType(NewRec);
+  }
+  case BTK__reflect_proxy: {
+    // __reflect_proxy<Interface, Impl> - proxy for Interface
+    assert(Converted.size() == 2 && "__reflect_proxy<Interface, Impl>");
+    TemplateArgument InterfaceArg = Converted[0], ImplArg = Converted[1];
+
+    QualType InterfaceTy = InterfaceArg.getAsType();
+    QualType ImplTy = ImplArg.getAsType();
+    auto *InterfaceRec = InterfaceTy->getAsCXXRecordDecl();
+    auto *ImplRec = ImplTy->getAsCXXRecordDecl();
+    if (!InterfaceRec || !ImplRec) {
+      SemaRef.Diag(TemplateArgs[0].getLocation(), CustomDiagID)
+          << "Arguments should be {Interface, Impl}";
+      return QualType();
+    }
+    CXXRecordDecl *NewRec = cast<CXXRecordDecl>(Context.buildImplicitRecord(
+        ("__reflect_proxy<"
+         + InterfaceRec->getName() + "," + ImplRec->getName() + ">").str(),
+        TTK_Class));
+    NewRec->startDefinition();
+    NewRec->addAttr(new (Context) FinalAttr(TemplateLoc, Context, false));
+    SmallVector<CXXBaseSpecifier *, 2> BaseInfo;
+    BaseInfo.push_back(
+      SemaRef.CheckBaseSpecifier(ImplRec, TemplateLoc, false, AS_public,
+                                 Context.getTrivialTypeSourceInfo(ImplTy),
+                                 SourceLocation()));
+    NewRec->setBases(BaseInfo.data(), 1);
+    auto RecTy = Context.getRecordType(NewRec);
+    auto ThisTy = Context.getPointerType(RecTy);
+    auto ImplPtrTy = Context.getPointerType(ImplTy);
+    QualType AutoType = Context.getAutoDeductType();
+
+    {
+      NestedNameSpecifier *NNS =
+        NestedNameSpecifier::Create(Context, nullptr,
+                                    false, ImplTy.getTypePtr());
+
+      Sema::ContextRAII SavedContext(SemaRef, NewRec);
+      CXXScopeSpec SS;
+      SS.MakeTrivial(Context, NNS, SourceRange(TemplateLoc));
+
+      // Generating "using Impl::Impl;"
+      DeclarationName ConstrName =
+        Context.DeclarationNames.getCXXConstructorName(
+          Context.getCanonicalType(ImplTy));
+      DeclarationNameInfo UsingNameInfo(ConstrName, ImplRec->getLocation());
+      SemaRef.BuildUsingDeclaration(
+          /*Scope*/ nullptr, AS_public, TemplateLoc,
+          /*HasTypename*/ false, {}, SS, UsingNameInfo, {},
+          ParsedAttributesView(),
+          /*IsInstantiation*/ true);
+    }
+
+    for (auto *Meth : InterfaceRec->methods()) {
+      if (Meth->isImplicit())
+        continue;
+      if (!Meth->hasAttr<TVMInternalFuncAttr>())
+        continue;
+      if (Meth->getName() == "constructor")
+        continue;
+
+      SmallVector<QualType, 8> MethArgs;
+      for (auto *Arg : Meth->parameters()) {
+        MethArgs.push_back(Arg->getType());
+      }
+
+      auto MethodType = Context.getFunctionType(AutoType, MethArgs,
+                                                FunctionProtoType::ExtProtoInfo());
+      auto *NewMeth = CXXMethodDecl::Create(Context, NewRec, SourceLocation(),
+        Meth->getNameInfo(), MethodType, /*TInfo=*/nullptr,
+        SC_None, true, false, SourceLocation());
+      NewMeth->addAttr(new (Context) FinalAttr(TemplateLoc, Context, false));
+
+      SmallVector<ParmVarDecl*, 8> Params;
+      for (unsigned i = 0, e = NewMeth->getNumParams(); i != e; ++i) {
+        ParmVarDecl *parm =
+            ParmVarDecl::Create(Context, NewMeth, SourceLocation(), SourceLocation(),
+                                nullptr, Meth->getParamDecl(i)->getType(), /*TInfo=*/nullptr,
+                                SC_None, nullptr);
+        parm->setScopeInfo(0, i);
+        Params.push_back(parm);
+      }
+      NewMeth->setParams(Params);
+      NewMeth->setAccess(AS_public);
+      NewMeth->setVirtualAsWritten(false);
+      NewMeth->setPure(false);
+      NewMeth->setTVMFuncId(Meth->getTVMFuncId());
+      TypeSourceInfo *TInfo =
+          Context.getTrivialTypeSourceInfo(NewMeth->getType(), TemplateLoc);
+      NewMeth->setTypeSourceInfo(TInfo);
+      Sema::SynthesizedFunctionScope Scope(SemaRef, NewMeth);
+      Expr *This = new (Context) CXXThisExpr(TemplateLoc, ThisTy, false);
+      CXXCastPath BasePath;
+      if (SemaRef.CheckDerivedToBaseConversion(RecTy, ImplTy,
+          TemplateLoc, ImplRec->getSourceRange(), &BasePath))
+        return QualType();
+      auto ThisBase = SemaRef.ImpCastExprToType(This, ImplPtrTy,
+         CK_UncheckedDerivedToBase, This->getValueKind(), &BasePath).get();
+      // Generating "return Impl::_call_impl<&Interface::function, Args...>(args...);"
+      const Type *ClassType =
+          Context.getTypeDeclType(Meth->getParent()).getTypePtr();
+      auto MethPtrTy = Context.getMemberPointerType(Meth->getType(), ClassType);
+      TemplateArgumentListInfo TArgs(TemplateLoc, TemplateLoc);
+      TemplateArgument MethPtrArg(Meth, MethPtrTy);
+      auto TL = SemaRef.getTrivialTemplateArgumentLoc(MethPtrArg, QualType(),
+                                                      TemplateLoc);
+      TArgs.addArgument(TL);
+
+      SmallVector<Expr *, 8> Args;
+      for (unsigned i = 0, e = NewMeth->getNumParams(); i != e; ++i) {
+        ParmVarDecl *Param = NewMeth->getParamDecl(i);
+        QualType ParamType = Param->getType().getNonReferenceType();
+        TemplateArgument CurArgT(ParamType);
+        TArgs.addArgument(
+          SemaRef.getTrivialTemplateArgumentLoc(CurArgT, QualType(),
+                                                TemplateLoc));
+        Args.push_back(
+          DeclRefExpr::Create(Context, NestedNameSpecifierLoc(),
+                              SourceLocation(), Param, false,
+                              TemplateLoc, ParamType,
+                              VK_LValue, nullptr));
+
+        Param->setReferenced(true);
+        Param->markUsed(Context);
+      }
+
+      ExprResult CallExpr =
+          buildMemberCall(SemaRef, ThisBase, TemplateLoc, "_call_impl",
+                          Args, &TArgs);
+      if (CallExpr.isInvalid())
+        return QualType();
+
+      Stmt *Return = SemaRef.BuildReturnStmt(TemplateLoc, CallExpr.get()).get();
+      NewMeth->setBody(CompoundStmt::Create(Context, Return, TemplateLoc,
+                                            TemplateLoc));
+      NewRec->addDecl(NewMeth);
+    }
     NewRec->completeDefinition();
     return Context.getRecordType(NewRec);
   }

--- a/llvm/tools/clang/test/CodeGen/tvm/test_call_proxy.cpp
+++ b/llvm/tools/clang/test/CodeGen/tvm/test_call_proxy.cpp
@@ -1,0 +1,83 @@
+// RUN: %clang -O3 -S -c -emit-llvm -target tvm %s --sysroot=%S/../../../../../projects/ton-compiler/cpp-sdk/ -o -
+// REQUIRES: tvm-registered-target
+
+#include <tvm/default_support_functions.hpp>
+#include <tvm/schema/message.hpp>
+#include <tvm/smart_switcher.hpp>
+#include <tvm/contract_handle.hpp>
+#include <tvm/replay_attack_protection/timestamp.hpp>
+
+using namespace tvm;
+using namespace schema;
+
+__interface IProposalRoot {
+  __attribute__((internal, external))
+  void constructor() = 1;
+
+  __attribute__((internal, noaccept))
+  void setFinished(bool_t val) = 2;
+
+  __attribute__((internal, noaccept))
+  bool_t checkFinished(uint32 answer_id) = 7;
+
+  // getters
+  __attribute__((getter))
+  bool_t isFinished() = 5;
+};
+
+/*
+  __reflect_proxy<IProposalRoot, Impl> generates class like this:
+class Proxy : public Impl {
+public:
+  using Impl::Impl;
+
+  auto checkFinished(uint32 answer_id) const {
+    return Impl::_call_impl<&IProposalRoot::checkFinished>(answer_id);
+  }
+  auto setFinished() const {
+    return Impl::_call_impl<&IProposalRoot::setFinished>();
+  }
+};
+*/
+
+// ================ Simulated contract code =================
+
+using IProposalRootPtr = handle<IProposalRoot>;
+
+__interface ITest {
+  __attribute__((internal, noaccept))
+  resumable<bool_t> checkAll() = 2;
+};
+
+struct DTest {
+  dict_array<uint256> proposals_;
+};
+
+struct ETest {
+};
+
+static constexpr unsigned TIMESTAMP_DELAY = 1800;
+
+class Test final : public smart_interface<ITest>, public DTest {
+public:
+  using replay_protection_t = replay_attack_protection::timestamp<TIMESTAMP_DELAY>;
+
+  __always_inline
+  resumable<bool_t> checkAll() {
+    for (auto proposal : proposals_) {
+      IProposalRootPtr handle(address::make_std(int8{0}, proposal));
+      uint32 answer_id{0};
+      bool_t finished = co_await handle(Grams(0)).checkFinished(answer_id);
+      if (!finished)
+        co_return bool_t{false};
+    }
+    co_return bool_t{true};
+  }
+  DEFAULT_SUPPORT_FUNCTIONS(ITest, replay_protection_t);
+};
+
+DEFINE_JSON_ABI(ITest, DTest, ETest);
+
+// ----------------------------- Main entry functions ---------------------- //
+DEFAULT_MAIN_ENTRY_FUNCTIONS(Test, ITest, DTest, TIMESTAMP_DELAY)
+


### PR DESCRIPTION
Nice remote call syntax:
`bool_t finished = co_await handle(Grams(0)).checkFinished(answer_id);`
Instead of `co_await handle(Grams(0)).call<&Interface::checkFinished>(answer_id)` before.