### PR TITLE
Generate shorter form instruction where it's possible

### DIFF
--- a/llvm/lib/Target/TVM/TVMInstrInfo.td
+++ b/llvm/lib/Target/TVM/TVMInstrInfo.td
@@ -208,6 +208,8 @@ defm XCPU : SI<(ins stack_op:$i, stack_op:$j), "XCPU\t$i, $j", 0x51>;
 defm PUXC : SI<(ins stack_op:$i, stack_op:$j), "PUXC\t$i, $j", 0x52>;
 // PUSH, PUSH
 defm PUSH2 : SI<(ins stack_op:$i, stack_op:$j), "PUSH2\t$i, $j", 0x53>;
+defm DUP2 : SI<(ins), "DUP2", 0x5c>;
+defm OVER2 : SI<(ins), "OVER2", 0x5d>;
 
 // XCHG, XCHG, XCHG
 defm XCHG3 : SI<(ins stack_op:$i, stack_op:$j, stack_op:$k),
@@ -215,6 +217,7 @@ defm XCHG3 : SI<(ins stack_op:$i, stack_op:$j, stack_op:$k),
 // XCHG, XCHG, PUSH
 defm XC2PU : SI<(ins stack_op:$i, stack_op:$j, stack_op:$k),
                 "XC2PU\t$i, $j, $k", 0x541>;
+defm TUCK : SI<(ins), "TUCK", 0x66>;
 // XCHG, PUSH, XCHG
 defm XCPUXC : SI<(ins stack_op:$i, stack_op:$j, stack_op:$k),
                  "XCPUXC\t$i, $j, $k", 0x542>;
@@ -240,8 +243,11 @@ def HIDDENSTACK : NI<(outs I257:$dst), (ins uimm8:$src), [(set I257:$dst, (int_t
 defm BLKPUSH : SI<(ins uimm8: $sz, uimm8:$slot), "BLKPUSH\t$sz, $slot", 0x5F>;
 defm POP  : SI<(ins stack_op:$dst), "POP\t$dst", 0x30>;
 defm BLKDROP : SI<(ins uimm8:$sz), "BLKDROP\t$sz", 0x5F0>;
+defm DROP2 : SI<(ins), "DROP2", 0x5B>;
 defm DROPX: SI<(ins), "DROPX", 0x65>;
 defm BLKSWAP : SI<(ins uimm8:$deep, uimm8:$top), "BLKSWAP\t$deep, $top", 0x55>;
+defm ROT : SI<(ins), "ROT", 0x58>;
+defm ROTREV : SI<(ins), "ROTREV", 0x59>;
 defm BLKSWX : SI<(ins), "BLKSWX", 0x63>;
 defm ROLL : SI<(ins uimm8:$sz), "ROLL\t$sz", 0x55>;
 defm ROLLREV : SI<(ins uimm8:$sz), "ROLLREV\t$sz", 0x55>;

--- a/llvm/lib/Target/TVM/TVMPeephole.cpp
+++ b/llvm/lib/Target/TVM/TVMPeephole.cpp
@@ -41,6 +41,10 @@ static cl::opt<bool>
 static cl::opt<bool> DisableTVMBlkPushOpt(
     "disable-tvm-push-opt", cl::Hidden,
     cl::desc("TVM: Disable BLKPUSH peephole optimizations."), cl::init(false));
+static cl::opt<bool> DisableTVMShorterFormOpt(
+    "disable-tvm-shorter-form-opt", cl::Hidden,
+    cl::desc("TVM: Disable shorter form replacement peephole optimizations."),
+    cl::init(false));
 static unsigned BlkPushLimit = 15;
 namespace {
 class TVMPeephole final : public MachineFunctionPass {
@@ -58,6 +62,8 @@ class TVMPeephole final : public MachineFunctionPass {
                                      const TargetInstrInfo &TII);
   bool runBlkDropCombine(MachineBasicBlock &MBB, const TargetInstrInfo &TII);
   bool runBlkPushCombine(MachineBasicBlock &MBB, const TargetInstrInfo &TII);
+  bool runReplaceWithShorterForm(MachineBasicBlock &MBB,
+                                 const TargetInstrInfo &TII);
   bool runMbbInlineOptimization(MachineBasicBlock &MBB,
                                 const TargetInstrInfo &TII);
   bool runIfElseOptimization(MachineBasicBlock &MBB,
@@ -181,6 +187,37 @@ bool TVMPeephole::runBlkPushCombine(MachineBasicBlock &MBB,
   for (auto *I : MIRemove)
     I->eraseFromParent();
   return Changed;
+}
+
+bool TVMPeephole::runReplaceWithShorterForm(MachineBasicBlock &MBB,
+                                            const TargetInstrInfo &TII) {
+  DenseMap<MachineInstr *, unsigned> MIReplace;
+  for (auto It = std::begin(MBB), E = std::end(MBB); It != E; ++It) {
+    if (It->getOpcode() == TVM::BLKDROP && It->getOperand(0).getImm() == 2)
+      MIReplace.insert({&*It, TVM::DROP2});
+    if (It->getOpcode() == TVM::PUSH2 && It->getOperand(0).getImm() == 1 &&
+        It->getOperand(1).getImm() == 0)
+      MIReplace.insert({&*It, TVM::DUP2});
+    if (It->getOpcode() == TVM::PUSH2 && It->getOperand(0).getImm() == 3 &&
+        It->getOperand(1).getImm() == 2)
+      MIReplace.insert({&*It, TVM::OVER2});
+    if (It->getOpcode() == TVM::BLKSWAP && It->getOperand(0).getImm() == 1 &&
+        It->getOperand(1).getImm() == 2)
+      MIReplace.insert({&*It, TVM::ROT});
+    if (It->getOpcode() == TVM::BLKSWAP && It->getOperand(0).getImm() == 2 &&
+        It->getOperand(1).getImm() == 1)
+      MIReplace.insert({&*It, TVM::ROTREV});
+    if (It->getOpcode() == TVM::ROLLREV && It->getOperand(0).getImm() == 2)
+      MIReplace.insert({&*It, TVM::ROTREV});
+    if (It->getOpcode() == TVM::XC2PU && It->getOperand(0).getImm() == 0 &&
+        It->getOperand(1).getImm() == 0 && It->getOperand(2).getImm() == 1)
+      MIReplace.insert({&*It, TVM::TUCK});
+  }
+  for (auto I : MIReplace) {
+    BuildMI(I.first, TII.get(I.second));
+    I.first->eraseFromParent();
+  }
+  return !MIReplace.empty();
 }
 
 bool TVMPeephole::runImplicitReturnOptimization(MachineBasicBlock &MBB,
@@ -563,6 +600,8 @@ bool TVMPeephole::runOnMachineBasicBlock(MachineBasicBlock &MBB,
     Changed |= runBlkDropCombine(MBB, TII);
   if (!DisableTVMBlkPushOpt)
     Changed |= runBlkPushCombine(MBB, TII);
+  if (!DisableTVMShorterFormOpt)
+    Changed |= runReplaceWithShorterForm(MBB, TII);
 
   return Changed;
 }

--- a/llvm/test/CodeGen/TVM/call/calln.ll
+++ b/llvm/test/CodeGen/TVM/call/calln.ll
@@ -19,7 +19,7 @@ define tuple @call_iti() {
 ; CHECK-LABEL: call_iti
 ; CHECK: CALL $ret_iti$
 ; CHECK-NEXT: XCHG	s1, s2
-; CHECK-NEXT: BLKDROP 2
+; CHECK-NEXT: DROP2
   %call = call %st_iti @ret_iti()
   %tup = extractvalue %st_iti %call, 1
   ret tuple %tup
@@ -31,7 +31,7 @@ define slice @call_isi() {
 ; CHECK-LABEL: call_isi
 ; CHECK: CALL $ret_isi$
 ; CHECK-NEXT: XCHG	s1, s2
-; CHECK-NEXT: BLKDROP 2
+; CHECK-NEXT: DROP2
   %call = call %st_isi @ret_isi()
   %sl = extractvalue %st_isi %call, 1
   ret slice %sl
@@ -43,7 +43,7 @@ define builder @call_ibi() {
 ; CHECK-LABEL: call_ibi
 ; CHECK: CALL $ret_ibi$
 ; CHECK-NEXT: XCHG	s1, s2
-; CHECK-NEXT: BLKDROP 2
+; CHECK-NEXT: DROP2
   %call = call %st_ibi @ret_ibi()
   %bld = extractvalue %st_ibi %call, 1
   ret builder %bld
@@ -55,7 +55,7 @@ define cell @call_ici() {
 ; CHECK-LABEL: call_ici
 ; CHECK: CALL $ret_ici$
 ; CHECK-NEXT: XCHG	s1, s2
-; CHECK-NEXT: BLKDROP 2
+; CHECK-NEXT: DROP2
   %call = call %st_ici @ret_ici()
   %cl = extractvalue %st_ici %call, 1
   ret cell %cl

--- a/llvm/test/CodeGen/TVM/semialias.ll
+++ b/llvm/test/CodeGen/TVM/semialias.ll
@@ -1,0 +1,61 @@
+; RUN: llc < %s -march=tvm -asm-verbose=false | FileCheck %s
+target datalayout = "E-S257-i1:257:257-i8:257:257-i16:257:257-i32:257:257-i64:257:257-i257:257:257-p:257:257-a:257:257"
+target triple = "tvm"
+
+declare i257 @foo(i257 %a, i257 %b, i257 %c, i257 %d)
+declare i257 @bar(i257 %a, i257 %b)
+declare i257 @baz(i257 %a, i257 %b, i257 %c)
+
+; CHECK-LABEL: swap2
+define i257 @swap2(i257 %a, i257 %b, i257 %c, i257 %d) nounwind {
+  ; TODO: ROLL ROLL is generated, should be SWAP2
+  %1 = call i257 @foo(i257 %c, i257 %d, i257 %a, i257 %b)
+  ret i257 %1
+}
+
+; CHECK-LABEL: drop2
+define i257 @drop2(i257 %a, i257 %b, i257 %c) nounwind {
+  ; CHECK: DROP2
+  ret i257 %a
+}
+
+; CHECK-LABEL: dup2
+define i257 @dup2(i257 %a, i257 %b) nounwind {
+  ; CHECK: DUP2
+  %1 = call i257 @bar(i257 %a, i257 %b)
+  %2 = add i257 %1, %a
+  %3 = add i257 %2, %b
+  ret i257 %3
+}
+
+; CHECK-LABEL: over2
+define i257 @over2(i257 %a, i257 %b, i257 %c, i257 %d) nounwind {
+  ; CHECK: OVER2
+  %1 = call i257 @bar(i257 %a, i257 %b)
+  %2 = add i257 %1, %a
+  %3 = add i257 %2, %b
+  %4 = add i257 %3, %c
+  %5 = add i257 %4, %d
+  ret i257 %5
+}
+
+; CHECK-LABEL: rot
+define i257 @rot(i257 %a, i257 %b, i257 %c) nounwind {
+  ; CHECK: ROT
+  %1 = call i257 @baz(i257 %b, i257 %c, i257 %a)
+  ret i257 %1
+}
+
+; CHECK-LABEL: rotrev
+define i257 @rotrev(i257 %a, i257 %b, i257 %c) nounwind {
+  ; CHECK: ROTREV
+  %1 = call i257 @baz(i257 %c, i257 %a, i257 %b)
+  ret i257 %1
+}
+
+; CHECK-LABEL: tuck
+define i257 @tuck(i257 %a, i257 %b) nounwind {
+  ; CHECK: TUCK
+  %1 = call i257 @baz(i257 %b, i257 %a, i257 %b)
+  ret i257 %1
+}

--- a/llvm/test/CodeGen/TVM/uint-cmp.ll
+++ b/llvm/test/CodeGen/TVM/uint-cmp.ll
@@ -6,7 +6,7 @@ target triple = "tvm"
 ; Function Attrs: norecurse nounwind readnone
 define dso_local i257 @ult_test(i257 %a, i257 %b) local_unnamed_addr norecurse nounwind readnone {
 ; CHECK-LABEL: ult_test:
-; CHECK:	PUSH2
+; CHECK:	DUP2
 ; CHECK:	LESS
 ; CHECK:	CONDSEL
 entry:
@@ -18,7 +18,7 @@ entry:
 ; Function Attrs: norecurse nounwind readnone
 define dso_local i257 @ule_test(i257 %a, i257 %b) local_unnamed_addr norecurse nounwind readnone {
 ; CHECK-LABEL: ule_test:
-; CHECK:	PUSH2
+; CHECK:	DUP2
 ; CHECK:	LEQ
 ; CHECK:	CONDSEL
 entry:
@@ -30,7 +30,7 @@ entry:
 ; Function Attrs: norecurse nounwind readnone
 define dso_local i257 @ugt_test(i257 %a, i257 %b) local_unnamed_addr norecurse nounwind readnone {
 ; CHECK-LABEL: ugt_test:
-; CHECK:	PUSH2
+; CHECK:	DUP2
 ; CHECK:	GREATER
 ; CHECK:	CONDSEL
 entry:
@@ -42,7 +42,7 @@ entry:
 ; Function Attrs: norecurse nounwind readnone
 define dso_local i257 @uge_test(i257 %a, i257 %b) local_unnamed_addr norecurse nounwind readnone {
 ; CHECK-LABEL: uge_test:
-; CHECK:	PUSH2
+; CHECK:	DUP2
 ; CHECK:	GEQ
 ; CHECK:	CONDSEL
 entry:


### PR DESCRIPTION
Replace stack manipulations with ROT, ROTREV, DROP2, DUP2, OVER2, TUCK where it
possible. Thus reduce gas cost by 8 gas per replacement.