### PR TITLE
implicit_func_id and return_name() attributes

### DIFF
--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/reflection.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/reflection.hpp
@@ -18,6 +18,8 @@ using get_interface_methods_count =
 template<class Interface, unsigned Index>
 using get_interface_method_name = __reflect_method_name<hana::string, Interface, Index>;
 template<class Interface, unsigned Index>
+using get_interface_return_name = __reflect_return_name<hana::string, Interface, Index>;
+template<class Interface, unsigned Index>
 using get_interface_method_func_id =
   __reflect_method_func_id<std::integral_constant, unsigned, Interface, Index>;
 template<class Interface, unsigned Index>
@@ -32,6 +34,9 @@ using get_interface_method_getter =
 template<class Interface, unsigned Index>
 using get_interface_method_noaccept =
   __reflect_method_noaccept<std::integral_constant, bool, Interface, Index>;
+template<class Interface, unsigned Index>
+using get_interface_method_implicit_func_id =
+  __reflect_method_implicit_func_id<std::integral_constant, bool, Interface, Index>;
 template<class Interface, unsigned Index>
 using get_interface_method_dyn_chain_parse =
   __reflect_method_dyn_chain_parse<std::integral_constant, bool, Interface, Index>;

--- a/llvm/tools/clang/include/clang/AST/ASTContext.h
+++ b/llvm/tools/clang/include/clang/AST/ASTContext.h
@@ -342,6 +342,8 @@ class ASTContext : public RefCountedBase<ASTContext> {
   mutable IdentifierInfo *ReflectMethodsCountName = nullptr;
   /// The identifier '__reflect_method_name'.
   mutable IdentifierInfo *ReflectMethodNameName = nullptr;
+  /// The identifier '__reflect_return_name'.
+  mutable IdentifierInfo *ReflectReturnNameName = nullptr;
   /// The identifier '__reflect_method_func_id'.
   mutable IdentifierInfo *ReflectMethodFuncIdName = nullptr;
   /// The identifier '__reflect_method_internal'.
@@ -352,6 +354,8 @@ class ASTContext : public RefCountedBase<ASTContext> {
   mutable IdentifierInfo *ReflectMethodGetterName = nullptr;
   /// The identifier '__reflect_method_noaccept'.
   mutable IdentifierInfo *ReflectMethodNoAcceptName = nullptr;
+  /// The identifier '__reflect_method_implicit_func_id'.
+  mutable IdentifierInfo *ReflectMethodImplicitFuncIdName = nullptr;
   /// The identifier '__reflect_method_dyn_chain_parse'.
   mutable IdentifierInfo *ReflectMethodDynChainParseName = nullptr;
   /// The identifier '__reflect_method_no_read_persistent'.
@@ -560,11 +564,13 @@ private:
   mutable BuiltinTemplateDecl *ReflectFieldsCountDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodsCountDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodNameDecl = nullptr;
+  mutable BuiltinTemplateDecl *ReflectReturnNameDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodFuncIdDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodInternalDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodExternalDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodGetterDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodNoAcceptDecl = nullptr;
+  mutable BuiltinTemplateDecl *ReflectMethodImplicitFuncIdDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodDynChainParseDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodNoReadPersistentDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodNoWritePersistentDecl = nullptr;
@@ -1084,11 +1090,13 @@ public:
   BuiltinTemplateDecl *getReflectFieldsCountDecl() const;
   BuiltinTemplateDecl *getReflectMethodsCountDecl() const;
   BuiltinTemplateDecl *getReflectMethodNameDecl() const;
+  BuiltinTemplateDecl *getReflectReturnNameDecl() const;
   BuiltinTemplateDecl *getReflectMethodFuncIdDecl() const;
   BuiltinTemplateDecl *getReflectMethodInternalDecl() const;
   BuiltinTemplateDecl *getReflectMethodExternalDecl() const;
   BuiltinTemplateDecl *getReflectMethodGetterDecl() const;
   BuiltinTemplateDecl *getReflectMethodNoAcceptDecl() const;
+  BuiltinTemplateDecl *getReflectMethodImplicitFuncIdDecl() const;
   BuiltinTemplateDecl *getReflectMethodDynChainParseDecl() const;
   BuiltinTemplateDecl *getReflectMethodNoReadPersistentDecl() const;
   BuiltinTemplateDecl *getReflectMethodNoWritePersistentDecl() const;
@@ -1882,6 +1890,12 @@ public:
     return ReflectMethodNameName;
   }
 
+  IdentifierInfo *getReflectReturnNameName() const {
+    if (!ReflectReturnNameName)
+      ReflectReturnNameName = &Idents.get("__reflect_return_name");
+    return ReflectReturnNameName;
+  }
+
   IdentifierInfo *getReflectMethodFuncIdName() const {
     if (!ReflectMethodFuncIdName)
       ReflectMethodFuncIdName = &Idents.get("__reflect_method_func_id");
@@ -1910,6 +1924,12 @@ public:
     if (!ReflectMethodNoAcceptName)
       ReflectMethodNoAcceptName = &Idents.get("__reflect_method_noaccept");
     return ReflectMethodNoAcceptName;
+  }
+
+  IdentifierInfo *getReflectMethodImplicitFuncIdName() const {
+    if (!ReflectMethodImplicitFuncIdName)
+      ReflectMethodImplicitFuncIdName = &Idents.get("__reflect_method_implicit_func_id");
+    return ReflectMethodImplicitFuncIdName;
   }
 
   IdentifierInfo *getReflectMethodDynChainParseName() const {

--- a/llvm/tools/clang/include/clang/Basic/Attr.td
+++ b/llvm/tools/clang/include/clang/Basic/Attr.td
@@ -1646,57 +1646,86 @@ def ObjCIndependentClass : InheritableAttr {
 
 // TVM local begin
 def TVMTupleStruct : InheritableAttr {
-  let Spellings = [Clang<"tvm_tuple">];
+  let Spellings = [GCC<"tvm_tuple">, CXX11<"", "tvm_tuple", 201309>,
+                   C2x<"", "tvm_tuple">];
   let Documentation = [Undocumented];
   let MeaningfulToClassTemplateDefinition = 1;
 }
 def TVMNoPubkeyInterface : InheritableAttr {
-  let Spellings = [Clang<"no_pubkey">];
+  let Spellings = [GCC<"no_pubkey">, CXX11<"", "no_pubkey", 201309>,
+                   C2x<"", "no_pubkey">];
   let Documentation = [Undocumented];
   let MeaningfulToClassTemplateDefinition = 1;
 }
 def TVMRawFunc : Attr {
-  let Spellings = [Clang<"tvm_raw_func">];
+  let Spellings = [GCC<"tvm_raw_func">, CXX11<"", "tvm_raw_func", 201309>,
+                   C2x<"", "tvm_raw_func">];
   let Documentation = [Undocumented];
   let Subjects = SubjectList<[Function]>;
 }
 def TVMInternalFunc : Attr {
-  let Spellings = [Clang<"internal">];
+  let Spellings = [GCC<"internal">, CXX11<"", "internal", 201309>,
+                   C2x<"", "internal">];
   let Documentation = [Undocumented];
   let Subjects = SubjectList<[Function]>;
 }
-def TVMExternalFunc : Attr {
-  let Spellings = [Clang<"external">];
+def TVMExternalFunc : InheritableAttr {
+  let Spellings = [GCC<"external">, CXX11<"", "external", 201309>,
+                   C2x<"", "external">];
   let Documentation = [Undocumented];
   let Subjects = SubjectList<[Function]>;
 }
 def TVMGetterFunc : Attr {
-  let Spellings = [Clang<"getter">];
+  let Spellings = [GCC<"getter">, CXX11<"", "getter", 201309>,
+                   C2x<"", "getter">];
   let Documentation = [Undocumented];
   let Subjects = SubjectList<[Function]>;
 }
 def TVMNoAcceptFunc : Attr {
-  let Spellings = [Clang<"noaccept">];
+  let Spellings = [GCC<"noaccept">, CXX11<"", "noaccept", 201309>,
+                   C2x<"", "noaccept">];
   let Documentation = [Undocumented];
   let Subjects = SubjectList<[Function]>;
 }
-def TVMDynChainParseFunc : Attr {
-  let Spellings = [Clang<"dyn_chain_parse">];
+def TVMImplicitFuncIdFunc : InheritableAttr {
+  let Spellings = [GCC<"implicit_func_id">,
+                   CXX11<"", "implicit_func_id", 201309>,
+                   C2x<"", "implicit_func_id">];
+  let Documentation = [Undocumented];
+  let Subjects = SubjectList<[Function]>;
+}
+def TVMDynChainParseFunc : InheritableAttr {
+  let Spellings = [GCC<"dyn_chain_parse">,
+                   CXX11<"", "dyn_chain_parse", 201309>,
+                   C2x<"", "dyn_chain_parse">];
+  let Documentation = [Undocumented];
+  let Subjects = SubjectList<[Function]>;
+}
+def TVMReturnNameFunc : InheritableAttr {
+  let Spellings = [GCC<"return_name">, CXX11<"", "return_name", 201309>,
+                   C2x<"", "return_name">];
+  let Args = [StringArgument<"ReturnName">];
+  let MeaningfulToClassTemplateDefinition = 1;
   let Documentation = [Undocumented];
   let Subjects = SubjectList<[Function]>;
 }
 def TVMNoReadPersistentFunc : Attr {
-  let Spellings = [Clang<"no_read_persistent">];
+  let Spellings = [GCC<"no_read_persistent">,
+                   CXX11<"", "no_read_persistent", 201309>,
+                   C2x<"", "no_read_persistent">];
   let Documentation = [Undocumented];
   let Subjects = SubjectList<[Function]>;
 }
 def TVMNoWritePersistentFunc : Attr {
-  let Spellings = [Clang<"no_write_persistent">];
+  let Spellings = [GCC<"no_write_persistent">,
+                   CXX11<"", "no_write_persistent", 201309>,
+                   C2x<"", "no_write_persistent">];
   let Documentation = [Undocumented];
   let Subjects = SubjectList<[Function]>;
 }
 def TVMNoPersistentFunc : Attr {
-  let Spellings = [Clang<"no_persistent">];
+  let Spellings = [GCC<"no_persistent">, CXX11<"", "no_persistent", 201309>,
+                   C2x<"", "no_persistent">];
   let Documentation = [Undocumented];
   let Subjects = SubjectList<[Function]>;
 }

--- a/llvm/tools/clang/include/clang/Basic/Builtins.h
+++ b/llvm/tools/clang/include/clang/Basic/Builtins.h
@@ -260,6 +260,9 @@ enum BuiltinTemplateKind : int {
   /// This names the __reflect_method_name BuiltinTemplateDecl.
   BTK__reflect_method_name,
 
+  /// This names the __reflect_return_name BuiltinTemplateDecl.
+  BTK__reflect_return_name,
+
   /// This names the __reflect_method_func_id BuiltinTemplateDecl.
   BTK__reflect_method_func_id,
 
@@ -274,6 +277,9 @@ enum BuiltinTemplateKind : int {
 
   /// This names the __reflect_method_noaccept BuiltinTemplateDecl.
   BTK__reflect_method_noaccept,
+
+  /// This names the __reflect_method_implicit_func_id BuiltinTemplateDecl.
+  BTK__reflect_method_implicit_func_id,
 
   /// This names the __reflect_method_dyn_chain_parse BuiltinTemplateDecl.
   BTK__reflect_method_dyn_chain_parse,

--- a/llvm/tools/clang/lib/AST/ASTContext.cpp
+++ b/llvm/tools/clang/lib/AST/ASTContext.cpp
@@ -1076,6 +1076,14 @@ ASTContext::getReflectMethodNameDecl() const {
 }
 
 BuiltinTemplateDecl *
+ASTContext::getReflectReturnNameDecl() const {
+  if (!ReflectReturnNameDecl)
+    ReflectReturnNameDecl = buildBuiltinTemplateDecl(
+        BTK__reflect_return_name, getReflectReturnNameName());
+  return ReflectReturnNameDecl;
+}
+
+BuiltinTemplateDecl *
 ASTContext::getReflectMethodFuncIdDecl() const {
   if (!ReflectMethodFuncIdDecl)
     ReflectMethodFuncIdDecl = buildBuiltinTemplateDecl(
@@ -1113,6 +1121,15 @@ ASTContext::getReflectMethodNoAcceptDecl() const {
     ReflectMethodNoAcceptDecl = buildBuiltinTemplateDecl(
         BTK__reflect_method_noaccept, getReflectMethodNoAcceptName());
   return ReflectMethodNoAcceptDecl;
+}
+
+BuiltinTemplateDecl *
+ASTContext::getReflectMethodImplicitFuncIdDecl() const {
+  if (!ReflectMethodImplicitFuncIdDecl)
+    ReflectMethodImplicitFuncIdDecl = buildBuiltinTemplateDecl(
+        BTK__reflect_method_implicit_func_id,
+        getReflectMethodImplicitFuncIdName());
+  return ReflectMethodImplicitFuncIdDecl;
 }
 
 BuiltinTemplateDecl *

--- a/llvm/tools/clang/lib/AST/DeclTemplate.cpp
+++ b/llvm/tools/clang/lib/AST/DeclTemplate.cpp
@@ -1324,10 +1324,10 @@ createReflectMethodsCountParameterList(const ASTContext &C, DeclContext *DC) {
                                        llvm::makeArrayRef(Params),
                                        SourceLocation(), nullptr);
 }
-// __reflect_method_name<T, Interface, Index> -
-//   name of the Interface method number #Index, provided into T<char...>
+
+// <StringType<char ...Chars>, Interface, Index>
 static TemplateParameterList *
-createReflectMethodNameParameterList(const ASTContext &C, DeclContext *DC) {
+createReflectStringParameterList(const ASTContext &C, DeclContext *DC) {
   // char ...Chars
   TypeSourceInfo *TI = C.getTrivialTypeSourceInfo(C.CharTy);
   auto *N = NonTypeTemplateParmDecl::Create(
@@ -1363,6 +1363,21 @@ createReflectMethodNameParameterList(const ASTContext &C, DeclContext *DC) {
   return TemplateParameterList::Create(C, SourceLocation(), SourceLocation(),
                                        llvm::makeArrayRef(Params),
                                        SourceLocation(), nullptr);
+}
+
+// __reflect_method_name<T, Interface, Index> -
+//   name of the Interface method number #Index, provided into T<char...>
+static TemplateParameterList *
+createReflectMethodNameParameterList(const ASTContext &C, DeclContext *DC) {
+  return createReflectStringParameterList(C, DC);
+}
+
+// __reflect_return_name<T, Interface, Index> -
+//   return_name[["name"]] of the Interface method number #Index,
+//   provided into T<char...>
+static TemplateParameterList *
+createReflectReturnNameParameterList(const ASTContext &C, DeclContext *DC) {
+  return createReflectStringParameterList(C, DC);
 }
 
 static TemplateParameterList *
@@ -1452,6 +1467,14 @@ static TemplateParameterList *
 createReflectMethodNoAcceptParameterList(const ASTContext &C, DeclContext *DC) {
   return createReflectMethodIntegralConstantParameterList(C, DC);
 }
+// __reflect_method_implicit_func_id<T, IntType, Interface, Index> -
+//   'implicit_func_id' attribute of the Interface method number #Index,
+//   provided into T<IntType, isInternal>
+static TemplateParameterList *
+createReflectMethodImplicitFuncIdParameterList(const ASTContext &C, DeclContext *DC) {
+  return createReflectMethodIntegralConstantParameterList(C, DC);
+}
+
 // __reflect_method_dyn_chain_parse<T, IntType, Interface, Index> -
 //   'dyn_chain_parse' attribute of the Interface method number #Index,
 //   provided into T<IntType, isInternal>
@@ -1763,6 +1786,8 @@ static TemplateParameterList *createBuiltinTemplateParameterList(
     return createReflectMethodsCountParameterList(C, DC);
   case BTK__reflect_method_name:
     return createReflectMethodNameParameterList(C, DC);
+  case BTK__reflect_return_name:
+    return createReflectReturnNameParameterList(C, DC);
   case BTK__reflect_method_func_id:
     return createReflectMethodFuncIdParameterList(C, DC);
   case BTK__reflect_method_internal:
@@ -1773,6 +1798,8 @@ static TemplateParameterList *createBuiltinTemplateParameterList(
     return createReflectMethodGetterParameterList(C, DC);
   case BTK__reflect_method_noaccept:
     return createReflectMethodNoAcceptParameterList(C, DC);
+  case BTK__reflect_method_implicit_func_id:
+    return createReflectMethodImplicitFuncIdParameterList(C, DC);
   case BTK__reflect_method_dyn_chain_parse:
     return createReflectMethodDynChainParseParameterList(C, DC);
   case BTK__reflect_method_no_read_persistent:

--- a/llvm/tools/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/llvm/tools/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5798,6 +5798,20 @@ static void handleDeprecatedAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
                                 AL.getAttributeSpellingListIndex()));
 }
 
+// TVM local begin
+static void handleReturnNameAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
+  // Handle the cases where the attribute has a text message.
+  StringRef Str;
+  if (AL.isArgExpr(0) && AL.getArgAsExpr(0) &&
+      !S.checkStringLiteralArgumentAttr(AL, 0, Str))
+    return;
+
+  D->addAttr(::new (S.Context)
+                 TVMReturnNameFuncAttr(AL.getRange(), S.Context, Str,
+                                       AL.getAttributeSpellingListIndex()));
+}
+// TVM local end
+
 static bool isGlobalVar(const Decl *D) {
   if (const auto *S = dyn_cast<VarDecl>(D))
     return S->hasGlobalStorage();
@@ -6399,8 +6413,14 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
   case ParsedAttr::AT_TVMNoAcceptFunc:
     handleSimpleAttribute<TVMNoAcceptFuncAttr>(S, D, AL);
     break;
+  case ParsedAttr::AT_TVMImplicitFuncIdFunc:
+    handleSimpleAttribute<TVMImplicitFuncIdFuncAttr>(S, D, AL);
+    break;
   case ParsedAttr::AT_TVMDynChainParseFunc:
     handleSimpleAttribute<TVMDynChainParseFuncAttr>(S, D, AL);
+    break;
+  case ParsedAttr::AT_TVMReturnNameFunc:
+    handleReturnNameAttr(S, D, AL);
     break;
   case ParsedAttr::AT_TVMNoReadPersistentFunc:
     handleSimpleAttribute<TVMNoReadPersistentFuncAttr>(S, D, AL);

--- a/llvm/tools/clang/lib/Sema/SemaLookup.cpp
+++ b/llvm/tools/clang/lib/Sema/SemaLookup.cpp
@@ -701,6 +701,9 @@ static bool LookupBuiltin(Sema &S, LookupResult &R) {
         } else if (II == S.getASTContext().getReflectMethodNameName()) {
           R.addDecl(S.getASTContext().getReflectMethodNameDecl());
           return true;
+        } else if (II == S.getASTContext().getReflectReturnNameName()) {
+          R.addDecl(S.getASTContext().getReflectReturnNameDecl());
+          return true;
         } else if (II == S.getASTContext().getReflectMethodFuncIdName()) {
           R.addDecl(S.getASTContext().getReflectMethodFuncIdDecl());
           return true;
@@ -715,6 +718,9 @@ static bool LookupBuiltin(Sema &S, LookupResult &R) {
           return true;
         } else if (II == S.getASTContext().getReflectMethodNoAcceptName()) {
           R.addDecl(S.getASTContext().getReflectMethodNoAcceptDecl());
+          return true;
+        } else if (II == S.getASTContext().getReflectMethodImplicitFuncIdName()) {
+          R.addDecl(S.getASTContext().getReflectMethodImplicitFuncIdDecl());
           return true;
         } else if (II == S.getASTContext().getReflectMethodDynChainParseName()) {
           R.addDecl(S.getASTContext().getReflectMethodDynChainParseDecl());


### PR DESCRIPTION
implicit_func_id means that abi for this function will be generated without specified `"id" = `. And external answer id will have `(1 << 31)` bit set.
return_name("output_name") attribute means that single return function will have "output_name" specified in json abi for return value instead of default "value0".
Also supported squared attribute representations (like `[[external, internal]][[return_name("contexts")]]`).