### PR TITLE
Calculated default hash func_ids

### DIFF
--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/chain_builder.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/chain_builder.hpp
@@ -15,8 +15,6 @@
 #include <boost/hana/take_back.hpp>
 #include <boost/hana/ext/std/tuple.hpp>
 
-#include <experimental/type_traits>
-
 namespace tvm {
 
 namespace hana = boost::hana;
@@ -42,15 +40,6 @@ struct extract_fit<Bits, Refs, Idx, Elem> {
 };
 
 template<class T>
-struct has_fmt_tuple {
-  using fmt_tuple = typename schema::make_builder_impl<T>::fmt_tuple;
-};
-template<class T>
-struct is_expandable : std::experimental::is_detected<has_fmt_tuple, T> {};
-template<class... Elems>
-struct is_expandable<std::tuple<Elems...>> : std::true_type {};
-
-template<class T>
 struct is_optional : std::false_type {};
 template<class T>
 struct is_optional<std::optional<T>> : std::true_type {};
@@ -65,7 +54,7 @@ static __always_inline builder build_chain(std::tuple<Elems...> tup) {
       // expanding first element
       auto first_elem = std::get<0>(tup);
       using first_elem_t = decltype(first_elem);
-      static_assert(is_expandable<first_elem_t>::value,
+      static_assert(schema::is_expandable<first_elem_t>::value,
                     "Can't place even 1 sequence element into cell");
       builder b;
       if constexpr (is_optional<first_elem_t>::value) {
@@ -107,7 +96,7 @@ struct chain_parser_impl<std::tuple<Elems...>, Offset, RefsOffset> {
       if constexpr (fit_count == 0) {
         // expanding first element
         using first_elem_t = typename std::tuple_element<0, Tup>::type;
-        static_assert(is_expandable<first_elem_t>::value,
+        static_assert(schema::is_expandable<first_elem_t>::value,
                       "Can't place even 1 sequence element into cell");
         first_elem_t elem;
         if constexpr (is_optional<first_elem_t>::value) {

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/chain_tuple.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/chain_tuple.hpp
@@ -35,7 +35,7 @@ auto make_chain_tuple(std::tuple<Elems...> tup) {
     // expanding first element
     auto first_elem = std::get<0>(tup);
     using first_elem_t = decltype(first_elem);
-    static_assert(is_expandable<first_elem_t>::value,
+    static_assert(schema::is_expandable<first_elem_t>::value,
                   "Can't place even 1 sequence element into cell");
     auto split_tup = make_chain_tuple(to_std_tuple(first_elem));
     if constexpr (sizeof...(Elems) > 1) {

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/contract.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/contract.hpp
@@ -15,6 +15,7 @@
 #include <tvm/schema/abiv1.hpp>
 #include <tvm/schema/json-abi-gen.hpp>
 #include <tvm/message_flags.hpp>
+#include <tvm/func_id.hpp>
 
 namespace tvm {
 

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/debot.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/debot.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <tvm/sequence.hpp>
+#include <tvm/schema/basics.hpp>
+
+namespace tvm { namespace debot {
+
+using namespace schema;
+
+static constexpr uint8 ACTION_EMPTY        {0u};
+static constexpr uint8 ACTION_RUN_ACTION   {1u};    // Call debot function associated with action
+static constexpr uint8 ACTION_RUN_METHOD   {2u};    // Call get-method of smart contract controlled by debot.
+static constexpr uint8 ACTION_SEND_MSG     {3u};    // Send a message to smart contract controlled by debot.
+static constexpr uint8 ACTION_INVOKE_DEBOT {4u};    // Call action from another debot
+static constexpr uint8 ACTION_PRINT		     {5u};    // Print string to user
+// set of helper actions that must be performed by debot engine
+static constexpr uint8 ACTION_CALL_ENGINE  {10u};    // Parse integer from string.
+
+static constexpr uint8 DEBOT_ABI           {1u};
+static constexpr uint8 DEBOT_TARGET_ABI    {2u};
+static constexpr uint8 DEBOT_TARGET_ADDR   {4u};
+
+static constexpr uint8 STATE_ZERO      {0u};   // initial state, before we start
+static constexpr uint8 STATE_STARTED   {1u};// "home" - after the start command
+static constexpr uint8 STATE_EXIT      {255u}; // we're done
+
+struct Action {
+  // String that describes action step, should be printed to user
+  string desc;
+  // Name of debot function that runs this action
+  string name;
+  // Action type
+  uint8 actionType;
+  // Action attributes.
+  // Syntax: "attr1,attr2,attr3=value,...".
+  // Example: "instant,fargs=fooFunc,sign=by-user,func=foo"
+  string attrs;
+  // Context to transit to
+	uint8 to;
+  // Action Context
+  cell misc;
+};
+
+struct Context {
+  string desc;      // message to be printed to the user
+  uint8 id;		      // Context ordinal
+  dict_array<Action> actions;	// list of actions
+};
+
+struct DebotVersion {
+  string name;
+  uint_t<24> semver;
+};
+
+struct DebotOptions {
+  uint8 options;
+  string debotAbi;
+  string targetAbi;
+  address targetAddr;
+};
+
+}} // namespace tvm::debot
+

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/func_id.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/func_id.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <tvm/reflection.hpp>
+#include <tvm/schema/json-abi-gen.hpp>
+
+namespace tvm {
+
+// If func_id is specified for method, returns it.
+// Otherwise, calculates by method signature.
+
+template<auto MethodPtr>
+constexpr unsigned get_func_id() {
+  using namespace schema;
+  constexpr unsigned explicit_id =
+    __reflect_method_ptr_func_id<std::integral_constant, unsigned, MethodPtr>::value;
+  if constexpr (explicit_id != 0) {
+    return explicit_id;
+  } else {
+    return get_signature_func_id<json_abi_gen::make_func_signature<MethodPtr>().c_str()>::value;
+  }
+}
+
+template<class Interface, unsigned Index>
+constexpr unsigned get_func_id() {
+  using namespace schema;
+  constexpr unsigned explicit_id =
+    __reflect_method_func_id<std::integral_constant, unsigned, Interface, Index>::value;
+  if constexpr (explicit_id != 0) {
+    return explicit_id;
+  } else {
+    return get_signature_func_id<json_abi_gen::make_func_signature<Interface, Index>().c_str()>::value;
+  }
+}
+
+// If func id is not specified or was specified attribute [[implicit_func_id]]
+template<class Interface, unsigned Index>
+constexpr unsigned is_implicit_func_id() {
+  constexpr unsigned explicit_id =
+    __reflect_method_func_id<std::integral_constant, unsigned, Interface, Index>::value;
+  return !explicit_id || get_interface_method_implicit_func_id<Interface, Index>::value;
+}
+
+template<auto MethodPtr>
+using id = std::integral_constant<unsigned, get_func_id<MethodPtr>()>;
+template<auto MethodPtr>
+static constexpr unsigned id_v = get_func_id<MethodPtr>();
+
+} // namespace tvm
+

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/reflection.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/reflection.hpp
@@ -17,6 +17,8 @@ using get_interface_methods_count =
   __reflect_methods_count<std::integral_constant, unsigned, Interface>;
 template<class Interface, unsigned Index>
 using get_interface_method_name = __reflect_method_name<hana::string, Interface, Index>;
+template<auto MethodPtr>
+using get_interface_method_ptr_name = __reflect_method_ptr_name<hana::string, MethodPtr>;
 template<class Interface, unsigned Index>
 using get_interface_return_name = __reflect_return_name<hana::string, Interface, Index>;
 template<class Interface, unsigned Index>
@@ -48,11 +50,18 @@ using get_interface_method_no_write_persistent =
   __reflect_method_no_write_persistent<std::integral_constant, bool, Interface, Index>;
 template<class Interface, unsigned Index>
 using get_interface_method_rv = __reflect_method_rv<Interface, Index>;
+template<auto MethodPtr>
+using get_interface_method_ptr_rv = __reflect_method_ptr_rv<MethodPtr>;
 template<class Interface, unsigned Index>
 using get_interface_method_arg_struct = __reflect_method_arg_struct<Interface, Index>;
+template<auto MethodPtr>
+using get_interface_method_ptr_arg_struct = __reflect_method_ptr_arg_struct<MethodPtr>;
 template<class Interface>
 using get_interface_has_pubkey =
   __reflect_interface_has_pubkey<std::integral_constant, bool, Interface>;
+template<const char* Signature>
+using get_signature_func_id =
+  __reflect_signature_func_id<std::integral_constant, unsigned, Signature>;
 
 template<auto MethodPtr>
 using args_struct_t = __reflect_method_ptr_arg_struct<MethodPtr>;
@@ -66,12 +75,6 @@ using built_value = Fmt;
 //  virtual built_value<Rv> Meth(parsed_value<ArgN>...)
 template<class Interface>
 using smart_interface = __reflect_smart_interface<parsed_value, built_value, Interface>;
-
-template<auto MethodPtr>
-using id = __reflect_method_ptr_func_id<std::integral_constant, unsigned, MethodPtr>;
-template<auto MethodPtr>
-static constexpr unsigned id_v =
-  __reflect_method_ptr_func_id<std::integral_constant, unsigned, MethodPtr>::value;
 
 template<auto MethodPtr>
 struct proxy_method {

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/schema/make_builder.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/schema/make_builder.hpp
@@ -6,6 +6,7 @@
 #include <tvm/schema/builder/variant_builder.hpp>
 #include <tvm/schema/builder/dynamic_field_builder.hpp>
 #include <tvm/schema/message.hpp>
+#include <experimental/type_traits>
 
 namespace tvm { namespace schema {
 
@@ -178,5 +179,15 @@ lazy<_Tp> lazy<_Tp>::make_std(int8 workchain, uint256 addr) {
   lazy<_Tp> rv{ MsgAddressInt{ addr_std{ {}, {}, int8{workchain}, addr } } };
   return rv;
 }
+
+// Helper to understand if this type is an expandable structure
+template<class T>
+struct has_fmt_tuple {
+  using fmt_tuple = typename make_builder_impl<T>::fmt_tuple;
+};
+template<class T>
+struct is_expandable : std::experimental::is_detected<has_fmt_tuple, T> {};
+template<class... Elems>
+struct is_expandable<std::tuple<Elems...>> : std::true_type {};
 
 }} // namespace tvm::schema

--- a/llvm/tools/clang/include/clang/AST/ASTContext.h
+++ b/llvm/tools/clang/include/clang/AST/ASTContext.h
@@ -342,6 +342,8 @@ class ASTContext : public RefCountedBase<ASTContext> {
   mutable IdentifierInfo *ReflectMethodsCountName = nullptr;
   /// The identifier '__reflect_method_name'.
   mutable IdentifierInfo *ReflectMethodNameName = nullptr;
+  /// The identifier '__reflect_method_ptr_name'.
+  mutable IdentifierInfo *ReflectMethodPtrNameName = nullptr;
   /// The identifier '__reflect_return_name'.
   mutable IdentifierInfo *ReflectReturnNameName = nullptr;
   /// The identifier '__reflect_method_func_id'.
@@ -366,6 +368,8 @@ class ASTContext : public RefCountedBase<ASTContext> {
   mutable IdentifierInfo *ReflectMethodPtrFuncIdName = nullptr;
   /// The identifier '__reflect_method_rv'.
   mutable IdentifierInfo *ReflectMethodRvName = nullptr;
+  /// The identifier '__reflect_method_ptr_rv'.
+  mutable IdentifierInfo *ReflectMethodPtrRvName = nullptr;
   /// The identifier '__reflect_method_arg_struct'.
   mutable IdentifierInfo *ReflectMethodArgStructName = nullptr;
   /// The identifier '__reflect_method_ptr_arg_struct'.
@@ -378,6 +382,8 @@ class ASTContext : public RefCountedBase<ASTContext> {
   mutable IdentifierInfo *ReflectMethodPtrName = nullptr;
   /// The identifier '__reflect_interface_has_pubkey'.
   mutable IdentifierInfo *ReflectInterfaceHasPubkeyName = nullptr;
+  /// The identifier '__reflect_signature_func_id'.
+  mutable IdentifierInfo *ReflectSignatureFuncIdName = nullptr;
   // TVM local end
 
   QualType ObjCConstantStringType;
@@ -564,6 +570,7 @@ private:
   mutable BuiltinTemplateDecl *ReflectFieldsCountDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodsCountDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodNameDecl = nullptr;
+  mutable BuiltinTemplateDecl *ReflectMethodPtrNameDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectReturnNameDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodFuncIdDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodInternalDecl = nullptr;
@@ -576,12 +583,14 @@ private:
   mutable BuiltinTemplateDecl *ReflectMethodNoWritePersistentDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodPtrFuncIdDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodRvDecl = nullptr;
+  mutable BuiltinTemplateDecl *ReflectMethodPtrRvDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodArgStructDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodPtrArgStructDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectSmartInterfaceDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectProxyDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodPtrDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectInterfaceHasPubkeyDecl = nullptr;
+  mutable BuiltinTemplateDecl *ReflectSignatureFuncIdDecl = nullptr;
   // TVM local end
 
   /// The associated SourceManager object.
@@ -1090,6 +1099,7 @@ public:
   BuiltinTemplateDecl *getReflectFieldsCountDecl() const;
   BuiltinTemplateDecl *getReflectMethodsCountDecl() const;
   BuiltinTemplateDecl *getReflectMethodNameDecl() const;
+  BuiltinTemplateDecl *getReflectMethodPtrNameDecl() const;
   BuiltinTemplateDecl *getReflectReturnNameDecl() const;
   BuiltinTemplateDecl *getReflectMethodFuncIdDecl() const;
   BuiltinTemplateDecl *getReflectMethodInternalDecl() const;
@@ -1102,12 +1112,14 @@ public:
   BuiltinTemplateDecl *getReflectMethodNoWritePersistentDecl() const;
   BuiltinTemplateDecl *getReflectMethodPtrFuncIdDecl() const;
   BuiltinTemplateDecl *getReflectMethodRvDecl() const;
+  BuiltinTemplateDecl *getReflectMethodPtrRvDecl() const;
   BuiltinTemplateDecl *getReflectMethodArgStructDecl() const;
   BuiltinTemplateDecl *getReflectMethodPtrArgStructDecl() const;
   BuiltinTemplateDecl *getReflectSmartInterfaceDecl() const;
   BuiltinTemplateDecl *getReflectProxyDecl() const;
   BuiltinTemplateDecl *getReflectMethodPtrDecl() const;
   BuiltinTemplateDecl *getReflectInterfaceHasPubkeyDecl() const;
+  BuiltinTemplateDecl *getReflectSignatureFuncIdDecl() const;
   // TVM local end
 
   // Builtin Types.
@@ -1890,6 +1902,12 @@ public:
     return ReflectMethodNameName;
   }
 
+  IdentifierInfo *getReflectMethodPtrNameName() const {
+    if (!ReflectMethodPtrNameName)
+      ReflectMethodPtrNameName = &Idents.get("__reflect_method_ptr_name");
+    return ReflectMethodPtrNameName;
+  }
+
   IdentifierInfo *getReflectReturnNameName() const {
     if (!ReflectReturnNameName)
       ReflectReturnNameName = &Idents.get("__reflect_return_name");
@@ -1964,6 +1982,12 @@ public:
     return ReflectMethodRvName;
   }
 
+  IdentifierInfo *getReflectMethodPtrRvName() const {
+    if (!ReflectMethodPtrRvName)
+      ReflectMethodPtrRvName = &Idents.get("__reflect_method_ptr_rv");
+    return ReflectMethodPtrRvName;
+  }
+
   IdentifierInfo *getReflectMethodArgStructName() const {
     if (!ReflectMethodArgStructName)
       ReflectMethodArgStructName = &Idents.get("__reflect_method_arg_struct");
@@ -1998,6 +2022,12 @@ public:
     if (!ReflectInterfaceHasPubkeyName)
       ReflectInterfaceHasPubkeyName = &Idents.get("__reflect_interface_has_pubkey");
     return ReflectInterfaceHasPubkeyName;
+  }
+
+  IdentifierInfo *getReflectSignatureFuncIdName() const {
+    if (!ReflectSignatureFuncIdName)
+      ReflectSignatureFuncIdName = &Idents.get("__reflect_signature_func_id");
+    return ReflectSignatureFuncIdName;
   }
   // TVM local end
 

--- a/llvm/tools/clang/include/clang/Basic/Builtins.h
+++ b/llvm/tools/clang/include/clang/Basic/Builtins.h
@@ -260,6 +260,9 @@ enum BuiltinTemplateKind : int {
   /// This names the __reflect_method_name BuiltinTemplateDecl.
   BTK__reflect_method_name,
 
+  /// This names the __reflect_method_ptr_name BuiltinTemplateDecl.
+  BTK__reflect_method_ptr_name,
+
   /// This names the __reflect_return_name BuiltinTemplateDecl.
   BTK__reflect_return_name,
 
@@ -296,6 +299,9 @@ enum BuiltinTemplateKind : int {
   /// This names the __reflect_method_rv BuiltinTemplateDecl.
   BTK__reflect_method_rv,
 
+  /// This names the __reflect_method_ptr_rv BuiltinTemplateDecl.
+  BTK__reflect_method_ptr_rv,
+
   /// This names the __reflect_method_arg_struct BuiltinTemplateDecl.
   BTK__reflect_method_arg_struct,
 
@@ -313,6 +319,9 @@ enum BuiltinTemplateKind : int {
 
   /// This names the __reflect_interface_has_pubkey BuiltinTemplateDecl.
   BTK__reflect_interface_has_pubkey,
+
+  /// This names the __reflect_signature_func_id BuiltinTemplateDecl.
+  BTK__reflect_signature_func_id,
   // TVM local end
 };
 

--- a/llvm/tools/clang/lib/AST/ASTContext.cpp
+++ b/llvm/tools/clang/lib/AST/ASTContext.cpp
@@ -1076,6 +1076,14 @@ ASTContext::getReflectMethodNameDecl() const {
 }
 
 BuiltinTemplateDecl *
+ASTContext::getReflectMethodPtrNameDecl() const {
+  if (!ReflectMethodPtrNameDecl)
+    ReflectMethodPtrNameDecl = buildBuiltinTemplateDecl(
+        BTK__reflect_method_ptr_name, getReflectMethodPtrNameName());
+  return ReflectMethodPtrNameDecl;
+}
+
+BuiltinTemplateDecl *
 ASTContext::getReflectReturnNameDecl() const {
   if (!ReflectReturnNameDecl)
     ReflectReturnNameDecl = buildBuiltinTemplateDecl(
@@ -1175,6 +1183,14 @@ ASTContext::getReflectMethodRvDecl() const {
 }
 
 BuiltinTemplateDecl *
+ASTContext::getReflectMethodPtrRvDecl() const {
+  if (!ReflectMethodPtrRvDecl)
+    ReflectMethodPtrRvDecl = buildBuiltinTemplateDecl(
+      BTK__reflect_method_ptr_rv, getReflectMethodRvName());
+  return ReflectMethodPtrRvDecl;
+}
+
+BuiltinTemplateDecl *
 ASTContext::getReflectMethodArgStructDecl() const {
   if (!ReflectMethodArgStructDecl)
     ReflectMethodArgStructDecl = buildBuiltinTemplateDecl(
@@ -1220,6 +1236,14 @@ ASTContext::getReflectInterfaceHasPubkeyDecl() const {
     ReflectInterfaceHasPubkeyDecl = buildBuiltinTemplateDecl(
         BTK__reflect_interface_has_pubkey, getReflectInterfaceHasPubkeyName());
   return ReflectInterfaceHasPubkeyDecl;
+}
+
+BuiltinTemplateDecl *
+ASTContext::getReflectSignatureFuncIdDecl() const {
+  if (!ReflectSignatureFuncIdDecl)
+    ReflectSignatureFuncIdDecl = buildBuiltinTemplateDecl(
+        BTK__reflect_signature_func_id, getReflectSignatureFuncIdName());
+  return ReflectSignatureFuncIdDecl;
 }
 
 RecordDecl *ASTContext::buildImplicitRecord(StringRef Name,

--- a/llvm/tools/clang/lib/Sema/SemaLookup.cpp
+++ b/llvm/tools/clang/lib/Sema/SemaLookup.cpp
@@ -701,6 +701,9 @@ static bool LookupBuiltin(Sema &S, LookupResult &R) {
         } else if (II == S.getASTContext().getReflectMethodNameName()) {
           R.addDecl(S.getASTContext().getReflectMethodNameDecl());
           return true;
+        } else if (II == S.getASTContext().getReflectMethodPtrNameName()) {
+          R.addDecl(S.getASTContext().getReflectMethodPtrNameDecl());
+          return true;
         } else if (II == S.getASTContext().getReflectReturnNameName()) {
           R.addDecl(S.getASTContext().getReflectReturnNameDecl());
           return true;
@@ -737,6 +740,9 @@ static bool LookupBuiltin(Sema &S, LookupResult &R) {
         } else if (II == S.getASTContext().getReflectMethodRvName()) {
           R.addDecl(S.getASTContext().getReflectMethodRvDecl());
           return true;
+        } else if (II == S.getASTContext().getReflectMethodPtrRvName()) {
+          R.addDecl(S.getASTContext().getReflectMethodPtrRvDecl());
+          return true;
         } else if (II == S.getASTContext().getReflectMethodArgStructName()) {
           R.addDecl(S.getASTContext().getReflectMethodArgStructDecl());
           return true;
@@ -754,6 +760,9 @@ static bool LookupBuiltin(Sema &S, LookupResult &R) {
           return true;
         } else if (II == S.getASTContext().getReflectInterfaceHasPubkeyName()) {
           R.addDecl(S.getASTContext().getReflectInterfaceHasPubkeyDecl());
+          return true;
+        } else if (II == S.getASTContext().getReflectSignatureFuncIdName()) {
+          R.addDecl(S.getASTContext().getReflectSignatureFuncIdDecl());
           return true;
         }
         // TVM local end

--- a/llvm/tools/clang/test/CodeGen/tvm/hash_func_id.cpp
+++ b/llvm/tools/clang/test/CodeGen/tvm/hash_func_id.cpp
@@ -1,0 +1,49 @@
+// RUN: %clang -O3 -S -c -emit-llvm -target tvm %s --sysroot=%S/../../../../../projects/ton-compiler/cpp-sdk/
+// REQUIRES: tvm-registered-target
+
+#include <tvm/contract.hpp>
+#include <tvm/smart_switcher.hpp>
+#include <tvm/contract_handle.hpp>
+#include <tvm/string.hpp>
+#include <tvm/replay_attack_protection/timestamp.hpp>
+#include <tvm/default_support_functions.hpp>
+#include <tvm/debot.hpp>
+
+using namespace tvm;
+using namespace schema;
+using namespace debot;
+
+__interface [[no_pubkey]] ISMV_Debot {
+
+  [[external, dyn_chain_parse]]
+  void constructor(uint8 options, string debotAbi, string targetAbi, address targetAddr);
+
+  [[external]]
+  [[return_name("contexts")]] dict_array<Context> fetch();
+
+  [[external]]
+  void start();
+
+  [[external]]
+  void quit();
+
+  [[external]]
+  DebotVersion getVersion();
+
+  [[external]]
+  DebotOptions getDebotOptions();
+};
+
+static_assert(get_func_id<&ISMV_Debot::constructor>() == 0x172daa29);
+static_assert(get_func_id<ISMV_Debot, 0>() == 0x172daa29);
+static_assert(get_func_id<&ISMV_Debot::fetch>() == 0x68c4f887);
+static_assert(get_func_id<ISMV_Debot, 1>() == 0x68c4f887);
+static_assert(get_func_id<&ISMV_Debot::start>() == 0x059c0d6f);
+static_assert(get_func_id<ISMV_Debot, 2>() == 0x059c0d6f);
+static_assert(get_func_id<&ISMV_Debot::quit>() == 0x30025d94);
+static_assert(get_func_id<ISMV_Debot, 3>() == 0x30025d94);
+static_assert(get_func_id<&ISMV_Debot::getVersion>() == 0x3541576f);
+static_assert(get_func_id<ISMV_Debot, 4>() == 0x3541576f);
+static_assert(get_func_id<&ISMV_Debot::getDebotOptions>() == 0x7decd0db);
+static_assert(get_func_id<ISMV_Debot, 5>() == 0x7decd0db);
+


### PR DESCRIPTION
Now you may use implicit func ids (calculated as hash from function signature).
```
__interface [[no_pubkey]] ISMV_Debot {

  [[external]]
  void start();
}
```
Also added helper structs / constants for debots engine.