### PR TITLE
Added contract template class support for internal/external processing.

### DIFF
--- a/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
@@ -768,6 +768,8 @@ static bool materializable(Instruction &V, Value *ThisPtr) {
     case Intrinsic::tvm_ctos:
     case Intrinsic::tvm_stu:
     case Intrinsic::tvm_sti:
+    case Intrinsic::tvm_stref:
+    case Intrinsic::tvm_stslice:
       return true;
     }
   }
@@ -975,9 +977,6 @@ void coro::buildCoroutineFrame(Function &F, Shape &Shape) {
               "token definition is separated from the use by a suspend point");
         // TVM local begin
         if (I.getType()->isTVMTupleTy())
-          report_fatal_error(
-              "TVM tuple definition is separated from the use by a suspend point");
-        if (I.getType()->isTVMBuilderTy())
           report_fatal_error(
               "TVM tuple definition is separated from the use by a suspend point");
         // TVM local end

--- a/llvm/lib/Transforms/Coroutines/TVMTypesSerialize.h
+++ b/llvm/lib/Transforms/Coroutines/TVMTypesSerialize.h
@@ -1,0 +1,398 @@
+//===- TVMTypesSerialize.h - Serialization/Deserialization for TVM --------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+// Serialization/Deserialization of TVM types into cells.
+// Used for serialization of coroutine frames.
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIB_TRANSFORMS_COROUTINES_TVMTYPESSERIALIZE_H
+#define LLVM_LIB_TRANSFORMS_COROUTINES_TVMTYPESSERIALIZE_H
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Transforms/Coroutines.h"
+#include "llvm/IR/Value.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Intrinsics.h"
+
+#include <variant>
+#include <vector>
+
+namespace llvm {
+
+template<class Stream, class T0, class ... Ts>
+Stream &operator<< (Stream &s,
+                    std::variant<T0, Ts...> const &v)
+{ std::visit([&](auto && arg){ s << arg;}, v); return s; }
+
+namespace coro {
+
+#ifdef TVMINTR
+#error TVMINTR override
+#endif
+#define TVMINTR(FUNC) \
+  Intrinsic::getDeclaration(&TheModule, FUNC)
+
+class int_ {
+public:
+  template<class OStream>
+  friend OStream &operator << (OStream &os, const int_ &val) {
+    os << "int" << val.sz_;
+    return os;
+  }
+  void store(Module &TheModule, IRBuilder<> &Builder, Value *&CellBuilder) {
+    auto *Load = Builder.CreateLoad(ptr_);
+    auto *Val = Builder.CreateSExt(Load, Builder.getInt257Ty());
+    CellBuilder = Builder.CreateCall(TVMINTR(Intrinsic::tvm_sti),
+      {Val, CellBuilder, Builder.getInt257(sz_)});
+  }
+  void load(Module &TheModule, IRBuilder<> &Builder, Value *&ReadSlice) {
+    auto *ElemSz = Builder.getInt257(sz_);
+    auto *ValAndSlice = Builder.CreateCall(TVMINTR(Intrinsic::tvm_ldi),
+                                           {ReadSlice, ElemSz});
+    auto *Val = Builder.CreateExtractValue(ValAndSlice, 0);
+    ReadSlice = Builder.CreateExtractValue(ValAndSlice, 1);
+    Val = Builder.CreateTruncOrBitCast(Val, ptr_->getType()->getPointerElementType());
+    Builder.CreateStore(Val, ptr_);
+  }
+  unsigned sz_;
+  Value *ptr_;
+};
+class uint_ {
+public:
+  template<class OStream>
+  friend OStream &operator << (OStream &os, const uint_ &val) {
+    os << "uint" << val.sz_;
+    return os;
+  }
+  void store(Module &TheModule, IRBuilder<> &Builder, Value *&CellBuilder) {
+    auto *Load = Builder.CreateLoad(ptr_);
+    auto *Val = Builder.CreateZExt(Load, Builder.getInt257Ty());
+    CellBuilder = Builder.CreateCall(TVMINTR(Intrinsic::tvm_stu),
+      {Val, CellBuilder, Builder.getInt257(sz_)});
+  }
+  void load(Module &TheModule, IRBuilder<> &Builder, Value *&ReadSlice) {
+    auto *ElemSz = Builder.getInt257(sz_);
+    auto *ValAndSlice = Builder.CreateCall(TVMINTR(Intrinsic::tvm_ldu),
+                                           {ReadSlice, ElemSz});
+    auto *Val = Builder.CreateExtractValue(ValAndSlice, 0);
+    ReadSlice = Builder.CreateExtractValue(ValAndSlice, 1);
+    Val = Builder.CreateTruncOrBitCast(Val, ptr_->getType()->getPointerElementType());
+    Builder.CreateStore(Val, ptr_);
+  }
+  unsigned sz_;
+  Value *ptr_;
+};
+class address_ {
+public:
+  template<class OStream>
+  friend OStream &operator << (OStream &os, const address_ &) {
+    os << "address";
+    return os;
+  }
+  void store(Module &TheModule, IRBuilder<> &Builder, Value *&CellBuilder) {
+    auto *Load = Builder.CreateLoad(ptr_);
+    CellBuilder = Builder.CreateCall(TVMINTR(Intrinsic::tvm_stslice),
+      {Load, CellBuilder});
+  }
+  void load(Module &TheModule, IRBuilder<> &Builder, Value *&ReadSlice) {
+    auto *ValAndSlice = Builder.CreateCall(TVMINTR(Intrinsic::tvm_ldmsgaddr),
+                                           {ReadSlice});
+    auto *Val = Builder.CreateExtractValue(ValAndSlice, 0);
+    ReadSlice = Builder.CreateExtractValue(ValAndSlice, 1);
+    Builder.CreateStore(Val, ptr_);
+  }
+  Value *ptr_;
+};
+class slice_ {
+  static constexpr unsigned SliceSizeBits = 10;
+public:
+  template<class OStream>
+  friend OStream &operator << (OStream &os, const slice_ &val) {
+    os << "slice" << val.sz_;
+    return os;
+  }
+  void store(Module &TheModule, IRBuilder<> &Builder, Value *&CellBuilder) {
+    auto *Load = Builder.CreateLoad(ptr_);
+    CellBuilder = Builder.CreateCall(TVMINTR(Intrinsic::tvm_stslice),
+      {Load, CellBuilder});
+  }
+  void load(Module &TheModule, IRBuilder<> &Builder, Value *&ReadSlice) {
+    auto *SliceSz = Builder.getInt257(sz_);
+    auto *ValAndSlice = Builder.CreateCall(TVMINTR(Intrinsic::tvm_ldslice),
+                                           {ReadSlice, SliceSz});
+    auto *Val = Builder.CreateExtractValue(ValAndSlice, 0);
+    ReadSlice = Builder.CreateExtractValue(ValAndSlice, 1);
+    Builder.CreateStore(Val, ptr_);
+  }
+  unsigned sz_;
+  Value *ptr_;
+};
+// slice with statically unknown size will be stored into separate cell
+class dyn_slice_ {
+public:
+  template<class OStream>
+  friend OStream &operator << (OStream &os, const dyn_slice_ &) {
+    os << "dyn_slice";
+    return os;
+  }
+  void store(Module &TheModule, IRBuilder<> &Builder, Value *&CellBuilder) {
+    auto *Load = Builder.CreateLoad(ptr_);
+    auto *NewC = Builder.CreateCall(TVMINTR(Intrinsic::tvm_newc), {});
+    NewC = Builder.CreateCall(TVMINTR(Intrinsic::tvm_stslice), {Load, NewC});
+    NewC = Builder.CreateCall(TVMINTR(Intrinsic::tvm_endc), {NewC});
+    CellBuilder = Builder.CreateCall(TVMINTR(Intrinsic::tvm_stref),
+      {NewC, CellBuilder});
+  }
+  void load(Module &TheModule, IRBuilder<> &Builder, Value *&ReadSlice) {
+    auto *ValAndSlice = Builder.CreateCall(TVMINTR(Intrinsic::tvm_ldrefrtos),
+                                           {ReadSlice});
+    auto *Val = Builder.CreateExtractValue(ValAndSlice, 1);
+    ReadSlice = Builder.CreateExtractValue(ValAndSlice, 0);
+    Builder.CreateStore(Val, ptr_);
+  }
+  Value *ptr_;
+};
+class cell_ {
+public:
+  template<class OStream>
+  friend OStream &operator << (OStream &os, const cell_ &) {
+    os << "cell";
+    return os;
+  }
+  void store(Module &TheModule, IRBuilder<> &Builder, Value *&CellBuilder) {
+    auto *Load = Builder.CreateLoad(ptr_);
+    CellBuilder = Builder.CreateCall(TVMINTR(Intrinsic::tvm_stref),
+      {Load, CellBuilder});
+  }
+  void load(Module &TheModule, IRBuilder<> &Builder, Value *&ReadSlice) {
+    auto *ValAndSlice = Builder.CreateCall(TVMINTR(Intrinsic::tvm_ldref),
+                                           {ReadSlice});
+    auto *Val = Builder.CreateExtractValue(ValAndSlice, 0);
+    ReadSlice = Builder.CreateExtractValue(ValAndSlice, 1);
+    Builder.CreateStore(Val, ptr_);
+  }
+  Value *ptr_;
+};
+// we serializing builder into cell,
+// and creating new builder on load (with stslice'ed old builder content)
+class builder_ {
+public:
+  template<class OStream>
+  friend OStream &operator << (OStream &os, const builder_ &) {
+    os << "builder";
+    return os;
+  }
+  void store(Module &TheModule, IRBuilder<> &Builder, Value *&CellBuilder) {
+    auto *Load = Builder.CreateLoad(ptr_);
+    auto *Cell = Builder.CreateCall(TVMINTR(Intrinsic::tvm_endc), {Load});
+    CellBuilder = Builder.CreateCall(TVMINTR(Intrinsic::tvm_stref),
+      {Cell, CellBuilder});
+  }
+  void load(Module &TheModule, IRBuilder<> &Builder, Value *&ReadSlice) {
+    auto *ValAndSlice = Builder.CreateCall(TVMINTR(Intrinsic::tvm_ldrefrtos),
+                                           {ReadSlice});
+    auto *Val = Builder.CreateExtractValue(ValAndSlice, 1);
+    ReadSlice = Builder.CreateExtractValue(ValAndSlice, 0);
+    Value *NewBuilder = Builder.CreateCall(TVMINTR(Intrinsic::tvm_newc), {});
+    NewBuilder = Builder.CreateCall(TVMINTR(Intrinsic::tvm_stslice),
+      {Val, NewBuilder});
+    Builder.CreateStore(NewBuilder, ptr_);
+  }
+  Value *ptr_;
+};
+class header_addr_ {
+public:
+  template<class OStream>
+  friend OStream &operator << (OStream &os, const header_addr_ &) {
+    os << "header_addr";
+    return os;
+  }
+  // header is loaded/stored outside (in smart_switcher), nothing to do here
+  void store(Module &, IRBuilder<> &, Value *&) {}
+  void load(Module &, IRBuilder<> &, Value *&) {}
+};
+
+using type_serializer =
+  std::variant<int_, uint_, address_, slice_, dyn_slice_,
+               cell_, builder_, header_addr_>;
+
+} // End namespace coro.
+
+using type_serializer = coro::type_serializer;
+
+class cell_pattern {
+  static constexpr unsigned max_cell_bits = 1023;
+  static constexpr unsigned max_cell_refs = 4;
+public:
+  cell_pattern() : bits_(0), refs_(0) {}
+  template<class OStream>
+  friend OStream &operator << (OStream &os, const cell_pattern &val) {
+    os << "(bits:" << val.bits_ << ", refs:" << val.refs_ << "){";
+    if (!val.types_.empty()) {
+      os << val.types_.front();
+      for (auto ty : make_range(std::next(val.types_.begin()), val.types_.end()))
+        os << ", " << ty;
+    }
+    os << "}";
+    return os;
+  }
+  bool fits(unsigned bits, unsigned refs, bool last) const {
+    if (bits_ + bits > max_cell_bits)
+      return false;
+    if (refs_ + refs > max_cell_refs)
+      return false;
+    if (refs_ + refs == max_cell_refs && !last)
+      return false;
+    return true;
+  }
+  void add(const type_serializer &ty, unsigned bits, unsigned refs) {
+    bits_ += bits;
+    refs_ += refs;
+    types_.push_back(ty);
+  }
+  Value *store(Module &TheModule, IRBuilder<> &Builder,
+               Value *CellBuilder, Value *NextCell) const {
+    for (const auto &ty : types_) {
+      std::visit([&](auto arg){ arg.store(TheModule, Builder, CellBuilder); }, ty);
+    }
+    if (NextCell)
+      CellBuilder = Builder.CreateCall(TVMINTR(Intrinsic::tvm_stref),
+                                       {NextCell, CellBuilder});
+    return Builder.CreateCall(TVMINTR(Intrinsic::tvm_endc), {CellBuilder});
+  }
+  void load(Module &TheModule, IRBuilder<> &Builder, Value *&ReadSlice) const {
+    for (const auto &ty : types_) {
+      std::visit([&](auto arg){ arg.load(TheModule, Builder, ReadSlice); }, ty);
+    }
+  }
+  std::vector<type_serializer> types_;
+  unsigned bits_;
+  unsigned refs_;
+};
+
+class types_pattern {
+  // schema::estimate_element<address>::max_bits
+  static constexpr unsigned address_max_bits = 808;
+public:
+  types_pattern(Module &TheModule, IRBuilder<> &Builder, StructType *FrameTy,
+                Value *Frame) {
+    // skipping already represented header
+    cells_.push_back(cell_pattern{});
+    cells_.back().add(coro::header_addr_{}, address_max_bits, 0);
+    // skipping resume_ptr, cleanup_ptr and promise
+    auto Elems = drop_begin(FrameTy->elements(), 3);
+    unsigned Idx = 3;
+    for (Type *Ty : Elems) {
+      auto *ElemPtr =
+        Builder.CreateConstInBoundsGEP2_32(FrameTy, Frame, 0, Idx);
+      if (Ty->isPointerTy()) {
+        contract_ptrs_.push_back(ElemPtr);
+      }
+      prepare_element(TheModule, Builder, Ty, ElemPtr,
+                      Idx + 1 == FrameTy->elements().size());
+      ++Idx;
+    }
+  }
+  void prepare_element(Module &TheModule, IRBuilder<> &Builder, Type *Ty,
+                       Value *Ptr, bool last) {
+    // TODO: generate error if pointer is not contract class type
+    if (Ty->isPointerTy())
+      return;
+    const auto &DL = TheModule.getDataLayout();
+    if (StructType *ElemSTy = dyn_cast<StructType>(Ty)) {
+      unsigned Idx = 0;
+      for (Type *Ty : ElemSTy->elements()) {
+        auto *ElemPtr =
+          Builder.CreateConstInBoundsGEP2_32(ElemSTy, Ptr, 0, Idx);
+        prepare_element(TheModule, Builder, Ty, ElemPtr, last);
+        ++Idx;
+      }
+      return;
+    } else if (ArrayType *ElemArray = dyn_cast<ArrayType>(Ty)) {
+      Type *SubTy = ElemArray->getElementType();
+      for (unsigned Idx = 0; Idx < ElemArray->getNumElements(); ++Idx) {
+        auto *ElemPtr =
+          Builder.CreateConstInBoundsGEP2_32(ElemArray, Ptr, 0, Idx);
+        prepare_element(TheModule, Builder, SubTy, ElemPtr, last);
+      }
+      return;
+    }
+    unsigned Sz = static_cast<unsigned>(DL.getTypeSizeInBits(Ty));
+    assert(Sz <= 257);
+    if (Ty->isTVMSliceTy()) {
+      // May be address, slice with fixed size or dynamic slice
+      if (false/*is_address*/) {
+      } else if (false/*is_fixed_size*/) {
+      } else {
+        check_overflow(0, 1, last);
+        cells_.back().add(coro::dyn_slice_{Ptr}, 0, 1);
+      }
+    } else if (Ty->isTVMCellTy()) {
+      check_overflow(0, 1, last);
+      cells_.back().add(coro::cell_{Ptr}, 0, 1);
+    } else if (Ty->isTVMBuilderTy()) {
+      check_overflow(0, 1, last);
+      cells_.back().add(coro::builder_{Ptr}, 0, 1);
+    } else if (Sz <= 256) {
+      check_overflow(Sz, 0, last);
+      cells_.back().add(coro::uint_{Sz, Ptr}, Sz, 0);
+    } else {
+      check_overflow(Sz, 0, last);
+      cells_.back().add(coro::int_{Sz, Ptr}, Sz, 0);
+    }
+  }
+  // In CellBuilder we already have serialized awaiting frame header
+  Value *store(Module &TheModule, IRBuilder<> &Builder, Value *StartBuilder) {
+    if (cells_.empty())
+      return Builder.CreateCall(TVMINTR(Intrinsic::tvm_endc), {StartBuilder});
+    Value *NextCell = nullptr;
+    for (const auto &cl : make_range(cells_.rbegin(), std::prev(cells_.rend()))) {
+      Value *CellBuilder = Builder.CreateCall(TVMINTR(Intrinsic::tvm_newc), {});
+      NextCell = cl.store(TheModule, Builder, CellBuilder, NextCell);
+    }
+    return cells_.front().store(TheModule, Builder, StartBuilder, NextCell);
+  }
+  void load(Module &TheModule, IRBuilder<> &Builder, Value *ReadSlice,
+            Value *NewThis) {
+    for (auto *ptr : contract_ptrs_) {
+      Builder.CreateStore(NewThis->stripPointerCasts(), ptr);
+    }
+    if (!cells_.empty())
+      return;
+    cells_.front().load(TheModule, Builder, ReadSlice);
+    for (const auto &cl : make_range(std::next(cells_.begin()), cells_.end())) {
+      auto *ValAndSlice = Builder.CreateCall(TVMINTR(Intrinsic::tvm_ldrefrtos),
+                                             {ReadSlice});
+      ReadSlice = Builder.CreateExtractValue(ValAndSlice, 1);
+      cl.load(TheModule, Builder, ReadSlice);
+    }
+  }
+  void check_overflow(unsigned bits, unsigned refs, bool last) {
+    if (cells_.empty() || !cells_.back().fits(bits, refs, last))
+      cells_.push_back(cell_pattern());
+  }
+  template<class OStream>
+  friend OStream &operator << (OStream &os, const types_pattern &val) {
+    os << "{";
+    if (!val.cells_.empty()) {
+      os << val.cells_.front();
+      for (auto ty : make_range(std::next(val.cells_.begin()), val.cells_.end()))
+        os << " | " << ty;
+    }
+    os << "}";
+    return os;
+  }
+  std::vector<cell_pattern> cells_;
+  std::vector<Value*> contract_ptrs_;
+};
+
+#undef TVMINTR
+
+} // End namespace llvm
+
+#endif

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/Console.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/Console.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <tvm/contract_handle.hpp>
+
+namespace tvm {
+
+__interface IConsole {
+  [[internal]]
+  schema::bool_t print(string message);
+
+  [[internal]]
+  string requestInput(string message);
+  [[internal]]
+  address requestAddress(string message);
+  [[internal]]
+  schema::uint32 requestUint32(string message);
+  [[internal]]
+  schema::uint256 requestPubkey(string message);
+  [[internal]]
+  schema::uint256 requestTONs(string message);
+
+  [[internal]]
+  schema::bool_t signAndSendExternal(cell msg);
+};
+
+using IConsolePtr = handle<IConsole>;
+
+} // namespace tvm
+

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/awaiting_responses_map.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/awaiting_responses_map.hpp
@@ -2,35 +2,50 @@
 
 #include <tvm/dict_map.hpp>
 #include <tvm/error_code.hpp>
+#include <tvm/schema/message.hpp>
 
 namespace tvm {
 
+struct awaiting_record {
+  schema::uint32 func_id;
+  schema::int8 waiting_workchain;
+  schema::uint256 waiting_addr;
+  schema::ref<schema::lazy<schema::MsgAddress>> return_addr;
+  // ... frame values
+};
+
 class awaiting_responses_map {
 public:
-  // works only for addr_std { kind:0b10, optional<Anycast>:0b0, workchain_id:uint8, address:uint256 }
-  static constexpr unsigned addr_size = 2 + 1 + 8 + 256;
-  static constexpr unsigned exec_id_size = 32;
-  static constexpr unsigned key_size = addr_size + exec_id_size;
+  static constexpr unsigned key_size = 32;
 
   __always_inline
-  void add_awaiting(slice addr, unsigned exec_id, cell state) {
-    slice key = make_key(addr, exec_id);
-    dict_.dictsetref(state, key, key_size);
+  schema::uint32 find_next_answer_id() {
+    do {
+      auto [cl, succ] = dict_.dictugetref(next_answer_id_.get(), key_size);
+      if (succ) {
+        ++next_answer_id_;
+        next_answer_id_ &= ((1u << 31) - 1);
+        continue;
+      }
+    } while (false);
+    return next_answer_id_;
   }
   __always_inline
-  cell find_awaiting(slice addr, unsigned exec_id) {
-    slice key = make_key(addr, exec_id);
-    auto [cl, succ] = dict_.dictdelgetref(key, key_size);
+  void add_awaiting(unsigned exec_id, cell state) {
+    dict_.dictusetref(state, exec_id, key_size);
+  }
+  __always_inline
+  cell find_awaiting(unsigned exec_id) {
+    auto [cl, succ] = dict_.dictugetref(exec_id, key_size);
     require(succ, error_code::unexpected_answer);
     return cl;
   }
   __always_inline
-  slice make_key(slice addr, unsigned exec_id) const {
-    slice sl = builder().stslice(addr).stu(exec_id, 32).make_slice();
-    require(sl.sbits() == key_size, error_code::wrong_awaiting_addr_size);
-    return sl;
+  void delete_awaiting(unsigned exec_id) {
+    dict_.dictudel(exec_id, key_size);
   }
 
+  schema::uint32 next_answer_id_;
   dictionary dict_;
 };
 

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/contract.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/contract.hpp
@@ -88,6 +88,31 @@ __attribute__((tvm_raw_func)) int main_merge(__tvm_cell msg, __tvm_slice msg_bod
   return 0;                                                                                \
 }
 
+// Contract class may be simple class, or template with parameter: `bool Internal`.
+// Template contract will instantiated with Internal=true for internal message pipeline,
+//  and with Internal=false for external message pipeline.
+#define DEFAULT_MAIN_ENTRY_FUNCTIONS_TMPL(Contract, IContract, DContract, TimestampDelay)  \
+__attribute__((tvm_raw_func)) int main_external(__tvm_cell msg, __tvm_slice msg_body) {    \
+  return smart_switch</*Internal=*/false, Contract<false>, IContract, DContract,           \
+                      replay_attack_protection::timestamp<TimestampDelay>>(msg, msg_body); \
+}                                                                                          \
+__attribute__((tvm_raw_func)) int main_internal(__tvm_cell msg, __tvm_slice msg_body) {    \
+  return smart_switch</*Internal=*/true, Contract<true>, IContract, DContract,             \
+                      replay_attack_protection::timestamp<TimestampDelay>>(msg, msg_body); \
+}                                                                                          \
+__attribute__((tvm_raw_func)) int main_ticktock(__tvm_cell msg, __tvm_slice msg_body) {    \
+  tvm_throw(error_code::unsupported_call_method);                                          \
+  return 0;                                                                                \
+}                                                                                          \
+__attribute__((tvm_raw_func)) int main_split(__tvm_cell msg, __tvm_slice msg_body) {       \
+  tvm_throw(error_code::unsupported_call_method);                                          \
+  return 0;                                                                                \
+}                                                                                          \
+__attribute__((tvm_raw_func)) int main_merge(__tvm_cell msg, __tvm_slice msg_body) {       \
+  tvm_throw(error_code::unsupported_call_method);                                          \
+  return 0;                                                                                \
+}
+
 // Prepare and send empty message with nanograms as transfer value.
 // Only internal destination address allowed.
 static void tvm_transfer(schema::MsgAddressInt dest, unsigned nanograms, bool bounce) {

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/contract.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/contract.hpp
@@ -13,6 +13,7 @@
 #include <tvm/schema/make_builder.hpp>
 #include <tvm/schema/message.hpp>
 #include <tvm/schema/abiv1.hpp>
+#include <tvm/schema/abiv2.hpp>
 #include <tvm/schema/json-abi-gen.hpp>
 #include <tvm/message_flags.hpp>
 #include <tvm/func_id.hpp>

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/error_code.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/error_code.hpp
@@ -17,7 +17,6 @@ struct error_code {
   static constexpr int unsupported_bounced_msg     = 55;
   static constexpr int no_persistent_data          = 56;
 
-  static constexpr int wrong_awaiting_addr_size    = 57;
   static constexpr int wrong_answer_id             = 58;
   static constexpr int unexpected_answer           = 59;
 

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/globals.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/globals.hpp
@@ -6,6 +6,7 @@ namespace global_id {
   static constexpr unsigned msg_global = 1;
   static constexpr unsigned coroutine_wait_addr = 2;
   static constexpr unsigned coroutine_answer_slice = 3;
+  static constexpr unsigned answer_id = 4;
 };
 
 } // namespace tvm

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/reflection.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/reflection.hpp
@@ -28,6 +28,9 @@ template<class Interface, unsigned Index>
 using get_interface_method_internal =
   __reflect_method_internal<std::integral_constant, bool, Interface, Index>;
 template<class Interface, unsigned Index>
+using get_interface_method_answer_id =
+  __reflect_method_answer_id<std::integral_constant, bool, Interface, Index>;
+template<class Interface, unsigned Index>
 using get_interface_method_external =
   __reflect_method_external<std::integral_constant, bool, Interface, Index>;
 template<class Interface, unsigned Index>
@@ -56,6 +59,12 @@ template<class Interface, unsigned Index>
 using get_interface_method_arg_struct = __reflect_method_arg_struct<Interface, Index>;
 template<auto MethodPtr>
 using get_interface_method_ptr_arg_struct = __reflect_method_ptr_arg_struct<MethodPtr>;
+template<auto MethodPtr>
+using get_interface_method_ptr_internal =
+  __reflect_method_ptr_internal<std::integral_constant, bool, MethodPtr>;
+template<auto MethodPtr>
+using get_interface_method_ptr_answer_id =
+  __reflect_method_ptr_answer_id<std::integral_constant, bool, MethodPtr>;
 template<class Interface>
 using get_interface_has_pubkey =
   __reflect_interface_has_pubkey<std::integral_constant, bool, Interface>;

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/schema/abiv2.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/schema/abiv2.hpp
@@ -36,6 +36,12 @@ struct internal_msg_header {
   uint32 function_id;
 };
 
+// internal contract calls for non-void methods require answer_id
+struct internal_msg_header_with_answer_id {
+  uint32 function_id;
+  uint32 answer_id;
+};
+
 static __always_inline unsigned answer_id(unsigned func_id) {
   return func_id | (1ul << 31);
 }

--- a/llvm/tools/clang/include/clang/AST/ASTContext.h
+++ b/llvm/tools/clang/include/clang/AST/ASTContext.h
@@ -350,6 +350,12 @@ class ASTContext : public RefCountedBase<ASTContext> {
   mutable IdentifierInfo *ReflectMethodFuncIdName = nullptr;
   /// The identifier '__reflect_method_internal'.
   mutable IdentifierInfo *ReflectMethodInternalName = nullptr;
+  /// The identifier '__reflect_method_ptr_internal'.
+  mutable IdentifierInfo *ReflectMethodPtrInternalName = nullptr;
+  /// The identifier '__reflect_method_answer_id'.
+  mutable IdentifierInfo *ReflectMethodAnswerIdName = nullptr;
+  /// The identifier '__reflect_method_ptr_answer_id'.
+  mutable IdentifierInfo *ReflectMethodPtrAnswerIdName = nullptr;
   /// The identifier '__reflect_method_external'.
   mutable IdentifierInfo *ReflectMethodExternalName = nullptr;
   /// The identifier '__reflect_method_getter'.
@@ -574,6 +580,9 @@ private:
   mutable BuiltinTemplateDecl *ReflectReturnNameDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodFuncIdDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodInternalDecl = nullptr;
+  mutable BuiltinTemplateDecl *ReflectMethodPtrInternalDecl = nullptr;
+  mutable BuiltinTemplateDecl *ReflectMethodAnswerIdDecl = nullptr;
+  mutable BuiltinTemplateDecl *ReflectMethodPtrAnswerIdDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodExternalDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodGetterDecl = nullptr;
   mutable BuiltinTemplateDecl *ReflectMethodNoAcceptDecl = nullptr;
@@ -1103,6 +1112,9 @@ public:
   BuiltinTemplateDecl *getReflectReturnNameDecl() const;
   BuiltinTemplateDecl *getReflectMethodFuncIdDecl() const;
   BuiltinTemplateDecl *getReflectMethodInternalDecl() const;
+  BuiltinTemplateDecl *getReflectMethodPtrInternalDecl() const;
+  BuiltinTemplateDecl *getReflectMethodAnswerIdDecl() const;
+  BuiltinTemplateDecl *getReflectMethodPtrAnswerIdDecl() const;
   BuiltinTemplateDecl *getReflectMethodExternalDecl() const;
   BuiltinTemplateDecl *getReflectMethodGetterDecl() const;
   BuiltinTemplateDecl *getReflectMethodNoAcceptDecl() const;
@@ -1924,6 +1936,24 @@ public:
     if (!ReflectMethodInternalName)
       ReflectMethodInternalName = &Idents.get("__reflect_method_internal");
     return ReflectMethodInternalName;
+  }
+
+  IdentifierInfo *getReflectMethodPtrInternalName() const {
+    if (!ReflectMethodPtrInternalName)
+      ReflectMethodPtrInternalName = &Idents.get("__reflect_method_ptr_internal");
+    return ReflectMethodPtrInternalName;
+  }
+
+  IdentifierInfo *getReflectMethodAnswerIdName() const {
+    if (!ReflectMethodAnswerIdName)
+      ReflectMethodAnswerIdName = &Idents.get("__reflect_method_answer_id");
+    return ReflectMethodAnswerIdName;
+  }
+
+  IdentifierInfo *getReflectMethodPtrAnswerIdName() const {
+    if (!ReflectMethodPtrAnswerIdName)
+      ReflectMethodPtrAnswerIdName = &Idents.get("__reflect_method_ptr_answer_id");
+    return ReflectMethodPtrAnswerIdName;
   }
 
   IdentifierInfo *getReflectMethodExternalName() const {

--- a/llvm/tools/clang/include/clang/Basic/Attr.td
+++ b/llvm/tools/clang/include/clang/Basic/Attr.td
@@ -1669,6 +1669,12 @@ def TVMInternalFunc : Attr {
   let Documentation = [Undocumented];
   let Subjects = SubjectList<[Function]>;
 }
+def TVMAnswerIdFunc : Attr {
+  let Spellings = [GCC<"answer_id">, CXX11<"", "answer_id", 201309>,
+                   C2x<"", "answer_id">];
+  let Documentation = [Undocumented];
+  let Subjects = SubjectList<[Function]>;
+}
 def TVMExternalFunc : InheritableAttr {
   let Spellings = [GCC<"external">, CXX11<"", "external", 201309>,
                    C2x<"", "external">];

--- a/llvm/tools/clang/include/clang/Basic/Builtins.h
+++ b/llvm/tools/clang/include/clang/Basic/Builtins.h
@@ -272,6 +272,15 @@ enum BuiltinTemplateKind : int {
   /// This names the __reflect_method_internal BuiltinTemplateDecl.
   BTK__reflect_method_internal,
 
+  /// This names the __reflect_method_ptr_internal BuiltinTemplateDecl.
+  BTK__reflect_method_ptr_internal,
+
+  /// This names the __reflect_method_answer_id BuiltinTemplateDecl.
+  BTK__reflect_method_answer_id,
+
+  /// This names the __reflect_method_ptr_answer_id BuiltinTemplateDecl.
+  BTK__reflect_method_ptr_answer_id,
+
   /// This names the __reflect_method_external BuiltinTemplateDecl.
   BTK__reflect_method_external,
 

--- a/llvm/tools/clang/lib/AST/ASTContext.cpp
+++ b/llvm/tools/clang/lib/AST/ASTContext.cpp
@@ -1108,6 +1108,30 @@ ASTContext::getReflectMethodInternalDecl() const {
 }
 
 BuiltinTemplateDecl *
+ASTContext::getReflectMethodPtrInternalDecl() const {
+  if (!ReflectMethodPtrInternalDecl)
+    ReflectMethodPtrInternalDecl = buildBuiltinTemplateDecl(
+        BTK__reflect_method_ptr_internal, getReflectMethodPtrInternalName());
+  return ReflectMethodPtrInternalDecl;
+}
+
+BuiltinTemplateDecl *
+ASTContext::getReflectMethodAnswerIdDecl() const {
+  if (!ReflectMethodAnswerIdDecl)
+    ReflectMethodAnswerIdDecl = buildBuiltinTemplateDecl(
+        BTK__reflect_method_answer_id, getReflectMethodAnswerIdName());
+  return ReflectMethodAnswerIdDecl;
+}
+
+BuiltinTemplateDecl *
+ASTContext::getReflectMethodPtrAnswerIdDecl() const {
+  if (!ReflectMethodPtrAnswerIdDecl)
+    ReflectMethodPtrAnswerIdDecl = buildBuiltinTemplateDecl(
+        BTK__reflect_method_ptr_answer_id, getReflectMethodPtrAnswerIdName());
+  return ReflectMethodPtrAnswerIdDecl;
+}
+
+BuiltinTemplateDecl *
 ASTContext::getReflectMethodExternalDecl() const {
   if (!ReflectMethodExternalDecl)
     ReflectMethodExternalDecl = buildBuiltinTemplateDecl(

--- a/llvm/tools/clang/lib/AST/DeclTemplate.cpp
+++ b/llvm/tools/clang/lib/AST/DeclTemplate.cpp
@@ -1702,7 +1702,7 @@ createReflectSmartInterfaceParameterList(const ASTContext &C, DeclContext *DC) {
                                        SourceLocation(), nullptr);
 }
 
-// __reflect_proxy<Interface, Impl> - Proxy class for Interface
+// __reflect_proxy<Interface, Impl, bool Internal> - Proxy class for Interface
 static TemplateParameterList *
 createReflectProxyParameterList(const ASTContext &C, DeclContext *DC) {
 
@@ -1718,7 +1718,14 @@ createReflectProxyParameterList(const ASTContext &C, DeclContext *DC) {
       /*Id=*/nullptr, /*Typename=*/true, /*ParameterPack=*/false);
   Impl->setImplicit(true);
 
-  NamedDecl *Params[] = { Interface, Impl };
+  // bool Internal
+  TypeSourceInfo *TInfo = C.getTrivialTypeSourceInfo(C.BoolTy);
+  auto *Internal = NonTypeTemplateParmDecl::Create(
+      C, DC, SourceLocation(), SourceLocation(), /*Depth=*/0, /*Position=*/2,
+      /*Id=*/nullptr, TInfo->getType(), /*ParameterPack=*/false, TInfo);
+  Internal->setImplicit(true);
+
+  NamedDecl *Params[] = { Interface, Impl, Internal };
   return TemplateParameterList::Create(C, SourceLocation(), SourceLocation(),
                                        llvm::makeArrayRef(Params),
                                        SourceLocation(), nullptr);

--- a/llvm/tools/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/llvm/tools/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6402,6 +6402,9 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
   case ParsedAttr::AT_TVMInternalFunc:
     handleSimpleAttribute<TVMInternalFuncAttr>(S, D, AL);
     break;
+  case ParsedAttr::AT_TVMAnswerIdFunc:
+    handleSimpleAttribute<TVMAnswerIdFuncAttr>(S, D, AL);
+    break;
   case ParsedAttr::AT_TVMExternalFunc:
     handleSimpleAttribute<TVMExternalFuncAttr>(S, D, AL);
     break;

--- a/llvm/tools/clang/lib/Sema/SemaLookup.cpp
+++ b/llvm/tools/clang/lib/Sema/SemaLookup.cpp
@@ -713,6 +713,15 @@ static bool LookupBuiltin(Sema &S, LookupResult &R) {
         } else if (II == S.getASTContext().getReflectMethodInternalName()) {
           R.addDecl(S.getASTContext().getReflectMethodInternalDecl());
           return true;
+        } else if (II == S.getASTContext().getReflectMethodPtrInternalName()) {
+          R.addDecl(S.getASTContext().getReflectMethodPtrInternalDecl());
+          return true;
+        } else if (II == S.getASTContext().getReflectMethodAnswerIdName()) {
+          R.addDecl(S.getASTContext().getReflectMethodAnswerIdDecl());
+          return true;
+        } else if (II == S.getASTContext().getReflectMethodPtrAnswerIdName()) {
+          R.addDecl(S.getASTContext().getReflectMethodPtrAnswerIdDecl());
+          return true;
         } else if (II == S.getASTContext().getReflectMethodExternalName()) {
           R.addDecl(S.getASTContext().getReflectMethodExternalDecl());
           return true;

--- a/llvm/tools/clang/test/CodeGen/tvm/Console_Debot.cpp
+++ b/llvm/tools/clang/test/CodeGen/tvm/Console_Debot.cpp
@@ -1,0 +1,153 @@
+// RUN: %clang -O3 -S -c -emit-llvm -target tvm %s --sysroot=%S/../../../../../projects/ton-compiler/cpp-sdk/ -o -
+// REQUIRES: tvm-registered-target
+
+#include <tvm/contract.hpp>
+#include <tvm/smart_switcher.hpp>
+#include <tvm/contract_handle.hpp>
+#include <tvm/string.hpp>
+#include <tvm/replay_attack_protection/timestamp.hpp>
+#include <tvm/debot.hpp>
+#include <tvm/default_support_functions.hpp>
+#include <tvm/Console.hpp>
+#include "SuperRoot.hpp"
+#include "MultisigWallet.hpp"
+
+using namespace tvm;
+using namespace schema;
+using namespace debot;
+
+using ISuperRootPtr = handle<ISuperRoot>;
+using IMultisigWalletPtr = handle<IMultisigWallet>;
+
+__interface [[no_pubkey]] ISMV_Debot {
+
+  [[external]]
+  void constructor();
+
+  [[external]]
+  [[return_name("contexts")]] dict_array<Context> fetch();
+
+  [[external]]
+  resumable<void> start();
+
+  [[external]]
+  void quit();
+
+  [[external]]
+  DebotVersion getVersion();
+
+  [[external]]
+  DebotOptions getDebotOptions();
+};
+
+struct DSMV_Debot {
+  std::optional<address> root_addr_;
+  std::optional<address> multisig_addr_;
+};
+
+__interface ESMV_Debot {
+};
+
+static constexpr unsigned TIMESTAMP_DELAY = 1800;
+using replay_protection_t = replay_attack_protection::timestamp<TIMESTAMP_DELAY>;
+
+class SMV_Debot final : public smart_interface<ISMV_Debot>, public DSMV_Debot {
+public:
+  __always_inline
+  void constructor() override {
+  }
+
+  __always_inline
+  dict_array<Context> fetch() override {
+    return {};
+  }
+  __always_inline
+  resumable<void> start() override {
+    co_await cout().print("Hello, I am SMV Debot!\n");
+
+    if (!root_addr_)
+      requestRootAddress();
+    if (!multisig_addr_)
+      requestMultisigAddress();
+
+    while(true) {
+      uint32 select = co_await cout().requestUint32("1). Create new proposal\n"
+                                                    "2). Create ballot for voting\n"
+                                                    "3). Change root address\n"
+                                                    "4). Change multisig address\n"
+                                                    "5). Exit\n");
+      switch (select.get()) {
+        case 1:
+          createNewProposal();
+          break;
+        case 2:
+          createBallot();
+          break;
+        case 3:
+          // TODO: Fix rematerialization for contract field pointers phi-nodes
+          // requestRootAddress();
+          break;
+        case 4:
+          // TODO: Fix rematerialization for contract field pointers phi-nodes
+          // requestMultisigAddress();
+          break;
+        case 5: co_return;
+      }
+    }
+  }
+  __always_inline
+  void quit() override {
+  }
+  __always_inline
+  DebotVersion getVersion() override {
+    return { .name = "SMV DeBot v0.1.1", .semver = uint_t<24>{(1u << 8) | 1} };
+  }
+  __always_inline
+  DebotOptions getDebotOptions() override {
+    return {
+      .options = uint8{0},
+      .debotAbi = "",
+      .targetAbi = "",
+      .targetAddr = address::make_std(int8{0}, uint256{0})
+    };
+  }
+  DEFAULT_SUPPORT_FUNCTIONS(ISMV_Debot, replay_protection_t)
+private:
+  IConsolePtr cout_ptr_ = IConsolePtr(address::make_std(schema::int8{0}, schema::uint256{0}));
+  __always_inline IConsolePtr::proxy cout() {
+    return cout_ptr_();
+  }
+  __always_inline
+  resumable<void> createNewProposal() {
+    co_return;
+  }
+  __always_inline
+  resumable<void> createBallot() {
+    address depool_addr = address::make_std(int8{0}, uint256{0});
+    uint256 pubkey = co_await cout().requestPubkey("Specify pubkey for ballot:\n");
+    uint256 tonsToBallot = co_await cout().requestTONs("TONs to ballot:\n");
+    uint256 tonsToProcess = co_await cout().requestTONs("Processing TONs (extra TONs will be returned back to your multisig):\n");
+    cell msg = ISuperRootPtr(*root_addr_).prepare_internal(Grams(tonsToProcess.get())).
+      createMultiBallot(pubkey, depool_addr, tonsToBallot);
+    cell external_msg = IMultisigWalletPtr(*multisig_addr_).prepare_external().
+      sendTransaction(*multisig_addr_, uint128{tonsToProcess.get()}, bool_t{true}, uint8{3}, msg);
+    co_await cout().print("Processing message...");
+    co_await cout().signAndSendExternal(external_msg);
+    co_await cout().print("Done.");
+  }
+
+  __always_inline
+  resumable<void> requestRootAddress() {
+    root_addr_ = co_await cout().requestAddress("Please, enter SMV root address:\n");
+  }
+  __always_inline
+  resumable<void> requestMultisigAddress() {
+    multisig_addr_ = co_await cout().requestAddress("Specify your multisig address:\n");
+  }
+};
+
+DEFINE_JSON_ABI(ISMV_Debot, DSMV_Debot, ESMV_Debot);
+
+// ----------------------------- Main entry functions ---------------------- //
+DEFAULT_MAIN_ENTRY_FUNCTIONS(SMV_Debot, ISMV_Debot, DSMV_Debot, TIMESTAMP_DELAY)
+

--- a/llvm/tools/clang/test/CodeGen/tvm/MultiBallot.hpp
+++ b/llvm/tools/clang/test/CodeGen/tvm/MultiBallot.hpp
@@ -1,0 +1,118 @@
+#pragma once
+
+#include <tvm/schema/message.hpp>
+
+#include <tvm/replay_attack_protection/timestamp.hpp>
+#include <tvm/smart_switcher.hpp>
+#include <tvm/dict_array.hpp>
+#include <tvm/dict_set.hpp>
+
+namespace tvm { namespace schema {
+
+using address = lazy<MsgAddressInt>;
+using VotesType = uint128;
+using DepositType = uint256;
+
+#define GASTOGRAM_WORKAROUND
+
+__always_inline unsigned gastogram(unsigned gas) {
+  // TODO: solve gastogram problem
+#ifdef GASTOGRAM_WORKAROUND
+  return gas * 10000;
+#else
+  return __builtin_tvm_gastogram(gas);
+#endif
+}
+
+static constexpr unsigned MULTI_BALLOT_TIMESTAMP_DELAY = 1800;
+using multi_ballot_replay_protection_t = replay_attack_protection::timestamp<MULTI_BALLOT_TIMESTAMP_DELAY>;
+
+struct sendVotesResult {
+  DepositType has_deposit;
+  DepositType already_sent_deposit;
+  DepositType new_sent_deposit;
+};
+
+struct requestDepositResult {
+  bool_t succeeded;
+  uint256 unfinished_proposal;
+};
+
+__interface IMultiBallot {
+
+  __attribute__((internal, noaccept))
+  void constructor() = 1;
+
+  // Initializes ballot variables
+  __attribute__((internal, noaccept))
+  void deployBallot() = 2;
+
+  // Receive native funds transfer and keep it in deposit
+  __attribute__((internal, noaccept))
+  void receiveNativeTransfer(DepositType amount) = 3;
+
+  // Receive stake transfer notify (from solidity IParticipant::onTransfer(address source, uint128 amount))
+  __attribute__((internal, noaccept))
+  void receiveStakeTransfer(address source, uint128 amount) = 0x23c4771d; // = hash_v<"onTransfer(address,uint128)()v2">
+
+  // ======= externals =======
+
+  // Sends all votes (for deposit) to Proposal Root contract
+  __attribute__((external, noaccept))
+  sendVotesResult sendVote(address proposal, bool_t yesOrNo) = 5;
+
+  // The function must request affected proposals the voting is finished,
+  // set to zero deposit variables and return stake and native deposits to user_wallet
+  __attribute__((external, noaccept))
+  resumable<void> requestDeposit(address user_wallet) = 6;
+
+  // send all remaining tons to user_wallet
+  __attribute__((external, noaccept))
+  void finalize(address user_wallet) = 7;
+
+  // ======= getters =======
+
+  __attribute__((getter))
+  DepositType getNativeDeposit() = 8;
+
+  __attribute__((getter))
+  DepositType getStakeDeposit() = 9;
+
+  __attribute__((getter, no_persistent))
+  DepositType getMultiBallot_receiveNativeTransfer_GasPrice() = 10;
+
+  __attribute__((getter, no_persistent))
+  DepositType getMultiBallot_receiveStakeTransfer_GasPrice() = 11;
+};
+
+struct DMultiBallot {
+  uint256 ballot_public_key_;
+  int8 workchain_id_;
+  uint256 super_root_;
+  address depool_;
+  DepositType native_deposit_;
+  DepositType stake_deposit_;
+
+  // map of voted proposal addresses to sent deposit
+  dict_map<uint256, DepositType> proposals_;
+};
+
+struct EMultiBallot {
+};
+
+// Prepare MultiBallot StateInit structure and expected contract address (hash from StateInit)
+inline
+std::pair<StateInit, uint256> prepare_ballot_state_init_and_addr(DMultiBallot ballot_data, cell ballot_code) {
+  cell ballot_data_cl =
+    prepare_persistent_data<IMultiBallot, multi_ballot_replay_protection_t, DMultiBallot>(
+      { multi_ballot_replay_protection_t::init(), {} }, ballot_data);
+  StateInit ballot_init {
+    /*split_depth*/{}, /*special*/{},
+    ballot_code, ballot_data_cl, /*library*/{}
+  };
+  cell ballot_init_cl = build(ballot_init).make_cell();
+  return { ballot_init, uint256(tvm_hash(ballot_init_cl)) };
+}
+
+}} // namespace tvm::schema
+

--- a/llvm/tools/clang/test/CodeGen/tvm/MultisigWallet.hpp
+++ b/llvm/tools/clang/test/CodeGen/tvm/MultisigWallet.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace tvm { namespace schema {
+
+__interface IMultisigWallet {
+  [[external]]
+  void sendTransaction(address dest, uint128 value, bool_t bounce, uint8 flags, cell payload);
+};
+
+}} // namespace tvm::schema
+

--- a/llvm/tools/clang/test/CodeGen/tvm/SuperRoot.hpp
+++ b/llvm/tools/clang/test/CodeGen/tvm/SuperRoot.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "MultiBallot.hpp"
+
+namespace tvm { namespace schema {
+
+struct Proposal {
+  address root;
+  // ...
+};
+
+struct GasPriceInfo {
+  uint64 flat_gas_limit;
+  uint64 flat_gas_price;
+};
+
+__interface ISuperRoot {
+
+  __attribute__((external,dyn_chain_parse))
+  void constructor(cell proposalRootCode, cell multiBallotCode) = 1;
+
+  // Adds new proposal to m_proposals, prepares initial data for new Proposal Root contract,
+  //  calculates it address and deploys it
+  __attribute__((internal, noaccept, dyn_chain_parse))
+  bool_t createProposal(uint256 id, address depool, VotesType totalVotes,
+                        uint32 startime, uint32 endtime, bytes desc,
+                        bool_t superMajority, DepositType votePrice,
+                        bool_t finalMsgEnabled, cell finalMsg, uint256 finalMsgValue,
+                        bool_t whiteListEnabled, dict_array<uint256> whitePubkeys) = 2;
+
+  // Create MultiBallot for user, to vote for proposals
+  __attribute__((internal, noaccept, dyn_chain_parse))
+  address createMultiBallot(uint256 pubkey, address depool, DepositType tonsToBallot) = 3;
+
+  // ============== getters ==============
+  __attribute__((getter, dyn_chain_parse))
+  address getMultiBallotAddress(uint256 pubkey, address depool) = 4;
+
+  __attribute__((getter))
+  Proposal getProposalById(uint256 id) = 5;
+
+  __attribute__((getter))
+  dict_array<uint256> getProposalIds() = 6;
+
+  __attribute__((getter))
+  address getProposalAddress(uint256 id) = 7;
+
+  __attribute__((getter, no_persistent))
+  DepositType getCreateMultiBallotGasPrice() = 8;
+};
+
+struct DSuperRoot {
+  cell proposal_root_code_;
+  cell multi_ballot_code_;
+  int8 workchain_id_;
+  DepositType start_balance_;
+  dict_map<uint256, Proposal> proposals_;
+};
+
+struct ESuperRoot {};
+
+}} // namespace tvm::schema
+


### PR DESCRIPTION
Depends on tonlabs/TON-Compiler#169

Added contract template class support for internal/external processing.
answer_id attribute for coroutines re-work.