### PR TITLE
tvm_rawreserve() and handle.deploy_noop() added

### DIFF
--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/contract.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/contract.hpp
@@ -26,6 +26,28 @@ inline void tvm_accept() {
 inline void tvm_commit() {
   __builtin_tvm_commit();
 }
+
+/* From tvm RAWRESERVE(x, y) :
+Creates an output action which would reserve
+  exactly x nanograms (if y = 0),
+  at most x nanograms (if y = 2), or
+  all but x nanograms (if y = 1 or y = 3),
+from the remaining balance of the account.
+It is roughly equivalent to creating an outbound message
+carrying x nanograms (or b − x nanograms, where b is the remaining
+balance) to oneself, so that the subsequent output actions would not
+be able to spend more money than the remainder.
+Bit +2 in y means that the external action does not fail if the specified amount cannot be
+reserved; instead, all remaining balance is reserved. Bit +8 in y means
+x ← −x before performing any further actions.
+Bit +4 in y means that x is increased by the original balance of the current account (before the
+compute phase), including all extra currencies, before performing any
+other checks and actions. Currently x must be a non-negative integer,
+and y must be in the range 0 ... 15. */
+
+inline void tvm_rawreserve(unsigned x, rawreserve_flag y) {
+  __builtin_tvm_rawreserve(x, static_cast<unsigned>(y));
+}
 inline void tvm_setcode(cell new_root_cell) {
   __builtin_tvm_setcode(new_root_cell);
 }

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/message_flags.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/message_flags.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <type_traits>
+
 // Message flags
 
 namespace tvm {
@@ -13,17 +15,45 @@ constexpr unsigned SENDER_WANTS_TO_PAY_FEES_SEPARATELY = 1;
 constexpr unsigned DEFAULT_MSG_FLAGS = SENDER_WANTS_TO_PAY_FEES_SEPARATELY | IGNORE_ACTION_ERRORS;
 
 // RAWRESERVE flags
+enum class rawreserve_flag {
+  none = 0x00,
+  all_except = 0x01,
+  // external action does not fail if the specified amount cannot be
+  //  reserved; instead, all remaining balance is reserved
+  up_to = 0x02,
+  // x is increased by the original balance of the current account (before the
+  //  compute phase), including all extra currencies, before performing any
+  //  other checks and actions.
+  add_balance = 0x04,
+  // x to −x before performing any further actions
+  minus_value = 0x08
+};
+
+__always_inline rawreserve_flag operator | (rawreserve_flag lhs, rawreserve_flag rhs) {
+  using T = std::underlying_type_t<rawreserve_flag>;
+  return static_cast<rawreserve_flag>(static_cast<T>(lhs) | static_cast<T>(rhs));
+}
+
+__always_inline rawreserve_flag& operator |= (rawreserve_flag& lhs, rawreserve_flag rhs) {
+  lhs = lhs | rhs;
+  return lhs;
+}
+
 // x to −x before performing any further actions
+[[deprecated]]
 constexpr unsigned RESERVE_MINUS_VALUE = 8;
 // x is increased by the original balance of the current account (before the
 //  compute phase), including all extra currencies, before performing any
 //  other checks and actions.
+[[deprecated]]
 constexpr unsigned RESERVE_ADD_BALANCE = 4;
 // external action does not fail if the specified amount cannot be
 //  reserved; instead, all remaining balance is reserved
+[[deprecated]]
 constexpr unsigned RESERVE_UP_TO = 2;
 
-constexpr unsigned RESERVE_ALL_EXCEPT = 1; 
+[[deprecated]]
+constexpr unsigned RESERVE_ALL_EXCEPT = 1;
 
 } // namespace tvm
 

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/schema/basics.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/schema/basics.hpp
@@ -550,6 +550,7 @@ struct varuint : boost::operators<varuint<_bitlen>> {
   varuint() : val_(0) {}
   varuint(unsigned val) : val_(val) {}
   unsigned operator()() const { return val_; }
+  unsigned get() const { return val_; }
   void operator()(unsigned val) { val_ = val; }
   auto& operator=(unsigned val) { val_ = val; return *this; }
   DEFAULT_PROXY_OPERATORS(varuint, unsigned)
@@ -561,6 +562,7 @@ struct varint : boost::operators<varint<_bitlen>> {
   varint() : val_(0) {}
   varint(int val) : val_(val) {}
   int operator()() const { return val_; }
+  int get() const { return val_; }
   void operator()(int val) { val_ = val; }
   auto& operator=(int val) { val_ = val; return *this; }
   DEFAULT_PROXY_OPERATORS(varint, int)


### PR DESCRIPTION
tvm_rawreserve() as a simple proxy to __builtin_tvm_reserve().
handle.deploy_noop() to deploy contract with message body function id = 0.