### PR TITLE
Fix store combine for negative constants

### DIFF
--- a/llvm/lib/Target/TVM/TVMMoveMaterializable.cpp
+++ b/llvm/lib/Target/TVM/TVMMoveMaterializable.cpp
@@ -72,7 +72,6 @@ private:
   bool processInstruction(MachineInstr &MI);
   bool runOnBasicBlocks(MachineFunction &MF);
 
-  TVMFunctionInfo *MFI;
   MachineRegisterInfo *MRI;
   const TargetInstrInfo *TII;
   LiveIntervals *LIS;

--- a/llvm/lib/Target/TVM/TVMStoreCombine.cpp
+++ b/llvm/lib/Target/TVM/TVMStoreCombine.cpp
@@ -110,8 +110,8 @@ static void combine(BasicBlock::iterator Start, BasicBlock::iterator End) {
     unsigned Sz = cast<ConstantInt>(CS.getArgument(2))->getZExtValue();
     if (Val.slt(0)) {
       APInt Pow2(257, 0, false);
-      Pow2.setBit(Sz);
-      Val = Pow2 - Val;
+      Pow2.setBit(Sz + 1);
+      Val = Pow2 - Val.abs();
     }
     Data <<= Sz;
     Size += Sz;

--- a/llvm/test/CodeGen/TVM/optimizations/store-opt.ll
+++ b/llvm/test/CodeGen/TVM/optimizations/store-opt.ll
@@ -14,7 +14,7 @@ define builder @test1() {
   %6 = call builder @llvm.tvm.sti(i257 -1, builder %5, i257 1)
   %7 = call builder @llvm.tvm.stu(i257 3, builder %6, i257 2)
   %8 = call builder @llvm.tvm.sti(i257 -7, builder %7, i257 3)
-  ; CHECK: %[[VR3:[0-9]+]] = call builder @llvm.tvm.stu(i257 127, builder %[[VR2]], i257 6)
+  ; CHECK: %[[VR3:[0-9]+]] = call builder @llvm.tvm.stu(i257 121, builder %[[VR2]], i257 6)
   %9 = call builder @llvm.tvm.sti(i257 -7, builder %8, i257 251)
   ; CHECK: %{{[0-9]+}} = call builder @llvm.tvm.sti(i257 -7, builder %[[VR3]], i257 251)
   ret builder %9


### PR DESCRIPTION
Two's compliment was calculated wrongly, the patch fixes it.