### PR TITLE
Before coroutines split casts must be relocated close to their operand

### DIFF
--- a/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
@@ -761,10 +761,6 @@ static bool materializable(Instruction &V, Value *ThisPtr) {
     case Intrinsic::tvm_pushslice_empty:
     case Intrinsic::tvm_newc:
     case Intrinsic::tvm_newdict:
-    case Intrinsic::tvm_cast_to_slice:
-    case Intrinsic::tvm_cast_to_builder:
-    case Intrinsic::tvm_cast_to_cell:
-    case Intrinsic::tvm_cast_to_tuple:
     case Intrinsic::tvm_cast_from_slice:
     case Intrinsic::tvm_cast_from_builder:
     case Intrinsic::tvm_cast_from_cell:
@@ -775,6 +771,14 @@ static bool materializable(Instruction &V, Value *ThisPtr) {
     case Intrinsic::tvm_stref:
     case Intrinsic::tvm_stslice:
       return true;
+    case Intrinsic::tvm_cast_to_slice:
+    case Intrinsic::tvm_cast_to_builder:
+    case Intrinsic::tvm_cast_to_cell:
+    case Intrinsic::tvm_cast_to_tuple: {
+      if (auto *SrcI = dyn_cast<Instruction>(V.getOperand(0)))
+        return materializable(*SrcI, ThisPtr);
+      return true;
+    }
     }
   }
   // Rematerializing load from contract class data for TVM

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/smart_switcher.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/smart_switcher.hpp
@@ -410,7 +410,7 @@ struct smart_switcher_impl {
       if constexpr (supports_set_persistent_data_header_v<Contract>)
         c.set_persistent_data_header(persistent_data_header);
 
-      using Args = get_interface_method_arg_struct<IContract, Index>;
+      using Args = get_interface_method_arg_struct<ISmart, Index>;
       constexpr unsigned args_sz = calc_fields_count<Args>::value;
       using rv_t = get_interface_method_rv<ISmart, Index>;
 

--- a/llvm/tools/clang/include/clang/Serialization/ASTBitCodes.h
+++ b/llvm/tools/clang/include/clang/Serialization/ASTBitCodes.h
@@ -1275,13 +1275,101 @@ namespace serialization {
 
       /// The internal '__type_pack_element' template.
       PREDEF_DECL_TYPE_PACK_ELEMENT_ID = 16,
+      // TVM local begin
+
+      /// The internal '__reflect_field' template.
+      PREDEF_DECL_REFLECT_FIELD_ID = 17,
+
+      /// The internal '__reflect_fields_count' template.
+      PREDEF_DECL_REFLECT_FIELDS_COUNT_ID = 18,
+
+      /// The internal '__reflect_methods_count' template.
+      PREDEF_DECL_REFLECT_METHODS_COUNT_ID = 19,
+
+      /// The internal '__reflect_method_name' template.
+      PREDEF_DECL_REFLECT_METHOD_NAME_ID = 20,
+
+      /// The internal '__reflect_method_ptr_name' template.
+      PREDEF_DECL_REFLECT_METHOD_PTR_NAME_ID = 21,
+
+      /// The internal '__reflect_return_name' template.
+      PREDEF_DECL_REFLECT_RETURN_NAME_ID = 22,
+
+      /// The internal '__reflect_method_func_id' template.
+      PREDEF_DECL_REFLECT_METHOD_FUNC_ID_ID = 23,
+
+      /// The internal '__reflect_method_internal' template.
+      PREDEF_DECL_REFLECT_METHOD_INTERNAL_ID = 24,
+
+      /// The internal '__reflect_method_ptr_internal' template.
+      PREDEF_DECL_REFLECT_METHOD_PTR_INTERNAL_ID = 25,
+
+      /// The internal '__reflect_method_answer_id' template.
+      PREDEF_DECL_REFLECT_METHOD_ANSWER_ID_ID = 26,
+
+      /// The internal '__reflect_method_ptr_answer_id' template.
+      PREDEF_DECL_REFLECT_METHOD_PTR_ANSWER_ID_ID = 27,
+
+      /// The internal '__reflect_method_external' template.
+      PREDEF_DECL_REFLECT_METHOD_EXTERNAL_ID = 28,
+
+      /// The internal '__reflect_method_getter' template.
+      PREDEF_DECL_REFLECT_METHOD_GETTER_ID = 29,
+
+      /// The internal '__reflect_method_noaccept' template.
+      PREDEF_DECL_REFLECT_METHOD_NOACCEPT_ID = 30,
+
+      /// The internal '__reflect_method_implicit_func_id' template.
+      PREDEF_DECL_REFLECT_METHOD_IMPLICIT_FUNC_ID_ID = 31,
+
+      /// The internal '__reflect_method_dyn_chain_parse' template.
+      PREDEF_DECL_REFLECT_METHOD_DYN_CHAIN_PARSE_ID = 32,
+
+      /// The internal '__reflect_method_no_read_persistent' template.
+      PREDEF_DECL_REFLECT_METHOD_NO_READ_PERSISTENT_ID = 33,
+
+      /// The internal '__reflect_method_no_write_persistent' template.
+      PREDEF_DECL_REFLECT_METHOD_NO_WRITE_PERSISTENT_ID = 34,
+
+      /// The internal '__reflect_method_ptr_func_id' template.
+      PREDEF_DECL_REFLECT_METHOD_PTR_FUNC_ID_ID = 35,
+
+      /// The internal '__reflect_method_rv' template.
+      PREDEF_DECL_REFLECT_METHOD_RV_ID = 36,
+
+      /// The internal '__reflect_method_ptr_rv' template.
+      PREDEF_DECL_REFLECT_METHOD_PTR_RV_ID = 37,
+
+      /// The internal '__reflect_method_arg_struct' template.
+      PREDEF_DECL_REFLECT_METHOD_ARG_STRUCT_ID = 38,
+
+      /// The internal '__reflect_method_ptr_arg_struct' template.
+      PREDEF_DECL_REFLECT_METHOD_PTR_ARG_STRUCT_ID = 39,
+
+      /// The internal '__reflect_smart_interface' template.
+      PREDEF_DECL_REFLECT_SMART_INTERFACE_ID = 40,
+
+      /// The internal '__reflect_proxy' template.
+      PREDEF_DECL_REFLECT_PROXY_ID = 41,
+
+      /// The internal '__reflect_method_ptr' template.
+      PREDEF_DECL_REFLECT_METHOD_PTR_ID = 42,
+
+      /// The internal '__reflect_interface_has_pubkey' template.
+      PREDEF_DECL_REFLECT_INTERFACE_HAS_PUBKEY_ID = 43,
+
+      /// The internal '__reflect_signature_func_id' template.
+      PREDEF_DECL_REFLECT_SIGNATURE_FUNC_ID_ID = 44
+      // TVM local end
     };
 
     /// The number of declaration IDs that are predefined.
     ///
     /// For more information about predefined declarations, see the
     /// \c PredefinedDeclIDs type and the PREDEF_DECL_*_ID constants.
-    const unsigned int NUM_PREDEF_DECL_IDS = 17;
+    // TVM local begin
+    const unsigned int NUM_PREDEF_DECL_IDS = 45;
+    // TVM local end
 
     /// Record of updates for a declaration that was modified after
     /// being deserialized. This can occur within DECLTYPES_BLOCK_ID.

--- a/llvm/tools/clang/lib/Serialization/ASTReader.cpp
+++ b/llvm/tools/clang/lib/Serialization/ASTReader.cpp
@@ -7334,6 +7334,94 @@ static Decl *getPredefinedDecl(ASTContext &Context, PredefinedDeclIDs ID) {
 
   case PREDEF_DECL_TYPE_PACK_ELEMENT_ID:
     return Context.getTypePackElementDecl();
+
+  // TVM local begin
+
+  case PREDEF_DECL_REFLECT_FIELD_ID:
+    return Context.getReflectFieldDecl();
+
+  case PREDEF_DECL_REFLECT_FIELDS_COUNT_ID:
+    return Context.getReflectFieldsCountDecl();
+
+  case PREDEF_DECL_REFLECT_METHODS_COUNT_ID:
+    return Context.getReflectMethodsCountDecl();
+
+  case PREDEF_DECL_REFLECT_METHOD_NAME_ID:
+    return Context.getReflectMethodNameDecl();
+
+  case PREDEF_DECL_REFLECT_METHOD_PTR_NAME_ID:
+    return Context.getReflectMethodPtrNameDecl();
+
+  case PREDEF_DECL_REFLECT_RETURN_NAME_ID:
+    return Context.getReflectReturnNameDecl();
+
+  case PREDEF_DECL_REFLECT_METHOD_FUNC_ID_ID:
+    return Context.getReflectMethodFuncIdDecl();
+
+  case PREDEF_DECL_REFLECT_METHOD_INTERNAL_ID:
+    return Context.getReflectMethodInternalDecl();
+
+  case PREDEF_DECL_REFLECT_METHOD_PTR_INTERNAL_ID:
+    return Context.getReflectMethodPtrInternalDecl();
+
+  case PREDEF_DECL_REFLECT_METHOD_ANSWER_ID_ID:
+    return Context.getReflectMethodAnswerIdDecl();
+
+  case PREDEF_DECL_REFLECT_METHOD_PTR_ANSWER_ID_ID:
+    return Context.getReflectMethodPtrAnswerIdDecl();
+
+  case PREDEF_DECL_REFLECT_METHOD_EXTERNAL_ID:
+    return Context.getReflectMethodExternalDecl();
+
+  case PREDEF_DECL_REFLECT_METHOD_GETTER_ID:
+    return Context.getReflectMethodGetterDecl();
+
+  case PREDEF_DECL_REFLECT_METHOD_NOACCEPT_ID:
+    return Context.getReflectMethodNoAcceptDecl();
+
+  case PREDEF_DECL_REFLECT_METHOD_IMPLICIT_FUNC_ID_ID:
+    return Context.getReflectMethodImplicitFuncIdDecl();
+
+  case PREDEF_DECL_REFLECT_METHOD_DYN_CHAIN_PARSE_ID:
+    return Context.getReflectMethodDynChainParseDecl();
+
+  case PREDEF_DECL_REFLECT_METHOD_NO_READ_PERSISTENT_ID:
+    return Context.getReflectMethodNoReadPersistentDecl();
+
+  case PREDEF_DECL_REFLECT_METHOD_NO_WRITE_PERSISTENT_ID:
+    return Context.getReflectMethodNoWritePersistentDecl();
+
+  case PREDEF_DECL_REFLECT_METHOD_PTR_FUNC_ID_ID:
+    return Context.getReflectMethodPtrFuncIdDecl();
+
+  case PREDEF_DECL_REFLECT_METHOD_RV_ID:
+    return Context.getReflectMethodRvDecl();
+
+  case PREDEF_DECL_REFLECT_METHOD_PTR_RV_ID:
+    return Context.getReflectMethodPtrRvDecl();
+
+  case PREDEF_DECL_REFLECT_METHOD_ARG_STRUCT_ID:
+    return Context.getReflectMethodArgStructDecl();
+
+  case PREDEF_DECL_REFLECT_METHOD_PTR_ARG_STRUCT_ID:
+    return Context.getReflectMethodPtrArgStructDecl();
+
+  case PREDEF_DECL_REFLECT_SMART_INTERFACE_ID:
+    return Context.getReflectSmartInterfaceDecl();
+
+  case PREDEF_DECL_REFLECT_PROXY_ID:
+    return Context.getReflectProxyDecl();
+
+  case PREDEF_DECL_REFLECT_METHOD_PTR_ID:
+    return Context.getReflectMethodPtrDecl();
+
+  case PREDEF_DECL_REFLECT_INTERFACE_HAS_PUBKEY_ID:
+    return Context.getReflectInterfaceHasPubkeyDecl();
+
+  case PREDEF_DECL_REFLECT_SIGNATURE_FUNC_ID_ID:
+    return Context.getReflectSignatureFuncIdDecl();
+
+  // TVM local end
   }
   llvm_unreachable("PredefinedDeclIDs unknown enum value");
 }

--- a/llvm/tools/clang/lib/Serialization/ASTWriter.cpp
+++ b/llvm/tools/clang/lib/Serialization/ASTWriter.cpp
@@ -4691,6 +4691,64 @@ ASTFileSignature ASTWriter::WriteASTCore(Sema &SemaRef, StringRef isysroot,
                      PREDEF_DECL_CF_CONSTANT_STRING_TAG_ID);
   RegisterPredefDecl(Context.TypePackElementDecl,
                      PREDEF_DECL_TYPE_PACK_ELEMENT_ID);
+  // TVM local begin
+  RegisterPredefDecl(Context.ReflectFieldDecl,
+                     PREDEF_DECL_REFLECT_FIELD_ID);
+  RegisterPredefDecl(Context.ReflectFieldsCountDecl,
+                     PREDEF_DECL_REFLECT_FIELDS_COUNT_ID);
+  RegisterPredefDecl(Context.ReflectMethodsCountDecl,
+                     PREDEF_DECL_REFLECT_METHODS_COUNT_ID);
+  RegisterPredefDecl(Context.ReflectMethodNameDecl,
+                     PREDEF_DECL_REFLECT_METHOD_NAME_ID);
+  RegisterPredefDecl(Context.ReflectMethodPtrNameDecl,
+                     PREDEF_DECL_REFLECT_METHOD_PTR_NAME_ID);
+  RegisterPredefDecl(Context.ReflectReturnNameDecl,
+                     PREDEF_DECL_REFLECT_RETURN_NAME_ID);
+  RegisterPredefDecl(Context.ReflectMethodFuncIdDecl,
+                     PREDEF_DECL_REFLECT_METHOD_FUNC_ID_ID);
+  RegisterPredefDecl(Context.ReflectMethodInternalDecl,
+                     PREDEF_DECL_REFLECT_METHOD_INTERNAL_ID);
+  RegisterPredefDecl(Context.ReflectMethodPtrInternalDecl,
+                     PREDEF_DECL_REFLECT_METHOD_PTR_INTERNAL_ID);
+  RegisterPredefDecl(Context.ReflectMethodAnswerIdDecl,
+                     PREDEF_DECL_REFLECT_METHOD_ANSWER_ID_ID);
+  RegisterPredefDecl(Context.ReflectMethodPtrAnswerIdDecl,
+                     PREDEF_DECL_REFLECT_METHOD_PTR_ANSWER_ID_ID);
+  RegisterPredefDecl(Context.ReflectMethodExternalDecl,
+                     PREDEF_DECL_REFLECT_METHOD_EXTERNAL_ID);
+  RegisterPredefDecl(Context.ReflectMethodGetterDecl,
+                     PREDEF_DECL_REFLECT_METHOD_GETTER_ID);
+  RegisterPredefDecl(Context.ReflectMethodNoAcceptDecl,
+                     PREDEF_DECL_REFLECT_METHOD_NOACCEPT_ID);
+  RegisterPredefDecl(Context.ReflectMethodImplicitFuncIdDecl,
+                     PREDEF_DECL_REFLECT_METHOD_IMPLICIT_FUNC_ID_ID);
+  RegisterPredefDecl(Context.ReflectMethodDynChainParseDecl,
+                     PREDEF_DECL_REFLECT_METHOD_DYN_CHAIN_PARSE_ID);
+  RegisterPredefDecl(Context.ReflectMethodNoReadPersistentDecl,
+                     PREDEF_DECL_REFLECT_METHOD_NO_READ_PERSISTENT_ID);
+  RegisterPredefDecl(Context.ReflectMethodNoWritePersistentDecl,
+                     PREDEF_DECL_REFLECT_METHOD_NO_WRITE_PERSISTENT_ID);
+  RegisterPredefDecl(Context.ReflectMethodPtrFuncIdDecl,
+                     PREDEF_DECL_REFLECT_METHOD_PTR_FUNC_ID_ID);
+  RegisterPredefDecl(Context.ReflectMethodRvDecl,
+                     PREDEF_DECL_REFLECT_METHOD_RV_ID);
+  RegisterPredefDecl(Context.ReflectMethodPtrRvDecl,
+                     PREDEF_DECL_REFLECT_METHOD_PTR_RV_ID);
+  RegisterPredefDecl(Context.ReflectMethodArgStructDecl,
+                     PREDEF_DECL_REFLECT_METHOD_ARG_STRUCT_ID);
+  RegisterPredefDecl(Context.ReflectMethodPtrArgStructDecl,
+                     PREDEF_DECL_REFLECT_METHOD_PTR_ARG_STRUCT_ID);
+  RegisterPredefDecl(Context.ReflectSmartInterfaceDecl,
+                     PREDEF_DECL_REFLECT_SMART_INTERFACE_ID);
+  RegisterPredefDecl(Context.ReflectProxyDecl,
+                     PREDEF_DECL_REFLECT_PROXY_ID);
+  RegisterPredefDecl(Context.ReflectMethodPtrDecl,
+                     PREDEF_DECL_REFLECT_METHOD_PTR_ID);
+  RegisterPredefDecl(Context.ReflectInterfaceHasPubkeyDecl,
+                     PREDEF_DECL_REFLECT_INTERFACE_HAS_PUBKEY_ID);
+  RegisterPredefDecl(Context.ReflectSignatureFuncIdDecl,
+                     PREDEF_DECL_REFLECT_SIGNATURE_FUNC_ID_ID);
+  // TVM local end
 
   // Build a record containing all of the tentative definitions in this file, in
   // TentativeDefinitions order.  Generally, this record will be empty for


### PR DESCRIPTION
to prevent values in wrong types at suspension points